### PR TITLE
Add an API endpoint to fetch user information

### DIFF
--- a/metadata_service/__init__.py
+++ b/metadata_service/__init__.py
@@ -15,6 +15,7 @@ from metadata_service.api.system import Neo4jDetailAPI
 from metadata_service.api.table \
     import TableDetailAPI, TableOwnerAPI, TableTagAPI, TableDescriptionAPI
 from metadata_service.api.tag import TagAPI
+from metadata_service.api.user import UserDetailAPI
 
 # For customized flask use below arguments to override.
 FLASK_APP_MODULE_NAME = os.getenv('FLASK_APP_MODULE_NAME')
@@ -83,6 +84,8 @@ def create_app(*, config_module_class: str) -> Flask:
                      '/latest_updated_ts')
     api.add_resource(TagAPI,
                      '/tags/')
+    api.add_resource(UserDetailAPI,
+                     '/user/<path:user_id>')
 
     app.register_blueprint(api_bp)
 

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -1,0 +1,37 @@
+from http import HTTPStatus
+from typing import Iterable, Mapping, Union
+
+from flask_restful import Resource, fields, marshal
+
+from metadata_service.exception import NotFoundException
+from metadata_service.proxy import neo4j_proxy
+
+
+user_detail_fields = {
+    'email': fields.String,
+    'first_name': fields.String,  # Optional
+    'last_name': fields.String,  # Optional
+    'full_name': fields.String,  # Optional
+    'is_active': fields.Boolean,  # Optional
+    'github_username': fields.String,  # Optional
+    'slack_id': fields.String,  # Optional
+    'team_name': fields.String,  # Optional
+    'employee_type': fields.String,  # Optional
+}
+
+
+class UserDetailAPI(Resource):
+    """
+    User detail API for people resources
+    """
+
+    def __init__(self) -> None:
+        self.neo4j = neo4j_proxy.get_neo4j()
+
+    def get(self, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        try:
+            table = self.neo4j.get_user_detail(user_id=user_id)
+            return marshal(table, user_detail_fields), HTTPStatus.OK
+
+        except NotFoundException:
+            return {'message': 'User id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND

--- a/metadata_service/entity/user_detail.py
+++ b/metadata_service/entity/user_detail.py
@@ -1,0 +1,42 @@
+class User:
+    def __init__(self, *,
+                 email: str,
+                 first_name: str =None,
+                 last_name: str =None,
+                 full_name: str =None,
+                 is_active: bool=True,
+                 github_username: str =None,
+                 team_name: str =None,
+                 slack_id: str =None,
+                 employee_type: str =None,
+                 ) -> None:
+        self.email = email
+        self.first_name = first_name
+        self.last_name = last_name
+        self.full_name = full_name
+        self.is_active = is_active
+        self.github_username = github_username
+        self.team_name = team_name
+        self.slack_id = slack_id
+        self.employee_type = employee_type
+
+    def __repr__(self) -> str:
+        return 'User(' \
+               'email={!r}, ' \
+               'first_name={!r}, ' \
+               'last_name={!r},' \
+               'full_name={!r},' \
+               'is_active={!r},' \
+               'github_username={!r},' \
+               'team_name={!r},' \
+               'slack_id={!r},' \
+               'employee_type={!r}' \
+               ')'.format(self.email,
+                          self.first_name,
+                          self.last_name,
+                          self.full_name,
+                          self.is_active,
+                          self.github_username,
+                          self.team_name,
+                          self.slack_id,
+                          self.employee_type)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 
 setup(
     name='amundsen-metadata',

--- a/tests/unit/test_neo4j_proxy.py
+++ b/tests/unit/test_neo4j_proxy.py
@@ -429,6 +429,25 @@ class TestGetTable(unittest.TestCase):
 
             self.assertEqual(actual.__repr__(), expected.__repr__())
 
+    def test_get_users(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            mock_execute.return_value.single.return_value = {
+                'user_record': {
+                    'employee_type': 'teamMember',
+                    'full_name': 'test_full_name',
+                    'is_active': 'True',
+                    'github_username': 'test-github',
+                    'slack_id': 'test_id',
+                    'last_name': 'test_last_name',
+                    'first_name': 'test_first_name',
+                    'team_name': 'test_team',
+                    'email': 'test_email'
+                }
+            }
+            neo4j_proxy = Neo4jProxy(endpoint='bogus')
+            neo4j_user = neo4j_proxy.get_user_detail(user_id='test_email')
+            self.assertEquals(neo4j_user.email, 'test_email')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The user model for "Amundsen People" could be found in https://github.com/lyft/amundsendatabuilder/blob/master/databuilder/models/user.py.

Add an API endpoint to fetch user based on user_id(email).

Test the endpoint locally with staging neo4j data:
```
curl http://localhost:5000/user/'tfeng@lyft.com'
{"email": "tfeng@lyft.com", "first_name": "Tao", "last_name": "Feng", "full_name": "Tao Feng", "is_active": true, "github_username": "", "slack_id": "", "team_name": "Data Platform", "employee_type": "teamMember"}
```

The databuilder has some issues on `github_user_name` field, but that would be a separate pr to fix.
Endpoint for bookmark, own, used three relationships will be in a separate pr.