### PR TITLE
[Amundsen People] Add API to build relationship between user and table

### DIFF
--- a/metadata_service/__init__.py
+++ b/metadata_service/__init__.py
@@ -15,7 +15,7 @@ from metadata_service.api.system import Neo4jDetailAPI
 from metadata_service.api.table \
     import TableDetailAPI, TableOwnerAPI, TableTagAPI, TableDescriptionAPI
 from metadata_service.api.tag import TagAPI
-from metadata_service.api.user import UserDetailAPI
+from metadata_service.api.user import UserDetailAPI, UserBookmarkAPI, UserOwnAPI, UserReadAPI
 
 # For customized flask use below arguments to override.
 FLASK_APP_MODULE_NAME = os.getenv('FLASK_APP_MODULE_NAME')
@@ -86,7 +86,15 @@ def create_app(*, config_module_class: str) -> Flask:
                      '/tags/')
     api.add_resource(UserDetailAPI,
                      '/user/<path:user_id>')
-
+    api.add_resource(UserBookmarkAPI,
+                     '/user/<path:user_id>/bookmark/',
+                     '/user/<path:user_id>/bookmark/<path:table_uri>')
+    api.add_resource(UserOwnAPI,
+                     '/user/<path:user_id>/own/',
+                     '/user/<path:user_id>/own/<path:table_uri>')
+    api.add_resource(UserReadAPI,
+                     '/user/<path:user_id>/read/',
+                     '/user/<path:user_id>/read/<path:table_uri>')
     app.register_blueprint(api_bp)
 
     return app

--- a/metadata_service/__init__.py
+++ b/metadata_service/__init__.py
@@ -15,7 +15,7 @@ from metadata_service.api.system import Neo4jDetailAPI
 from metadata_service.api.table \
     import TableDetailAPI, TableOwnerAPI, TableTagAPI, TableDescriptionAPI
 from metadata_service.api.tag import TagAPI
-from metadata_service.api.user import UserDetailAPI, UserBookmarkAPI, UserOwnAPI, UserReadAPI
+from metadata_service.api.user import UserDetailAPI, UserFollowAPI, UserOwnAPI, UserReadAPI
 
 # For customized flask use below arguments to override.
 FLASK_APP_MODULE_NAME = os.getenv('FLASK_APP_MODULE_NAME')
@@ -86,15 +86,15 @@ def create_app(*, config_module_class: str) -> Flask:
                      '/tags/')
     api.add_resource(UserDetailAPI,
                      '/user/<path:user_id>')
-    api.add_resource(UserBookmarkAPI,
-                     '/user/<path:user_id>/bookmark/',
-                     '/user/<path:user_id>/bookmark/<path:table_uri>')
+    api.add_resource(UserFollowAPI,
+                     '/user/<path:user_id>/follow/',
+                     '/user/<path:user_id>/follow/<resource_type>/<path:table_uri>')
     api.add_resource(UserOwnAPI,
                      '/user/<path:user_id>/own/',
-                     '/user/<path:user_id>/own/<path:table_uri>')
+                     '/user/<path:user_id>/own/<resource_type>/<path:table_uri>')
     api.add_resource(UserReadAPI,
                      '/user/<path:user_id>/read/',
-                     '/user/<path:user_id>/read/<path:table_uri>')
+                     '/user/<path:user_id>/read/<resource_type>/<path:table_uri>')
     app.register_blueprint(api_bp)
 
     return app

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Iterable, Mapping, Union
+from typing import Iterable, Mapping, Union, Optional, Any, Tuple
 
 from flask_restful import Resource, fields, marshal
 
@@ -36,3 +36,203 @@ class UserDetailAPI(Resource):
 
         except NotFoundException:
             return {'message': 'User id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+
+
+class UserBookmarkAPI(Resource):
+    """
+    Build get / put API to support user bookmark resource features.
+    It will create a relationship(follow / followed_by) between user and resources(table, dashboard etc)
+    """
+
+    def __init__(self) -> None:
+        self.neo4j = neo4j_proxy.get_neo4j()
+
+    def get(self, user_id: str) -> Tuple:
+        """
+        Return a list of resources that user has followed
+
+        :param user_id:
+        :return:
+        """
+        try:
+            resources = self.neo4j.get_resources_by_user_relation(user_id=user_id,
+                                                                  relation='FOLLOW')
+            return {'table': resources}, HTTPStatus.OK
+
+        except NotFoundException:
+            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+
+        except Exception:
+            return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def put(self, table_uri: str, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        """
+        Create the relationship between user and resources.
+        todo: It will need to refactor all neo4j proxy api to take a type argument.
+
+        :param user_id:
+        :param table_uri:
+        :return:
+        """
+        try:
+            self.neo4j.add_resource_relation_by_user(table_uri=table_uri,
+                                                     user=user_id,
+                                                     relation='FOLLOW',
+                                                     reverse_relation='FOLLOWED_BY')
+            return {'message': 'The user {} for table_uri {} '
+                               'is added successfully'.format(user_id,
+                                                              table_uri)}, HTTPStatus.OK
+        except Exception as e:
+            return {'message': 'The user {} for table_uri {} '
+                               'is not added successfully'.format(user_id,
+                                                                  table_uri)}, \
+                   HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def delete(self, table_uri: str, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        """
+        Delete the relationship between user and resources.
+        todo: It will need to refactor all neo4j proxy api to take a type argument.
+
+        :param user_id:
+        :param table_uri:
+        :return:
+        """
+        try:
+            self.neo4j.delete_resource_relation_by_user(table_uri=table_uri,
+                                                        user=user_id,
+                                                        relation='FOLLOW',
+                                                        reverse_relation='FOLLOWED_BY')
+            return {'message': 'The user {} for table_uri {} '
+                               'is added successfully'.format(user_id,
+                                                              table_uri)}, HTTPStatus.OK
+        except Exception as e:
+            return {'message': 'The user {} for table_uri {} '
+                               'is not added successfully'.format(user_id,
+                                                                  table_uri)}, \
+                   HTTPStatus.INTERNAL_SERVER_ERROR
+
+
+class UserOwnAPI(Resource):
+    """
+    Build get / put API to support user own resource features.
+    It will create a relationship(owner / owner_of) between user and resources(table, dashboard etc)
+    todo: Deprecate TableOwner API
+    """
+
+    def __init__(self) -> None:
+        self.neo4j = neo4j_proxy.get_neo4j()
+
+    def get(self, user_id: str) -> Tuple:
+        """
+        Return a list of resources that user has owned
+
+        :param user_id:
+        :return:
+        """
+        try:
+            resources = self.neo4j.get_resources_by_user_relation(user_id=user_id,
+                                                                  relation='OWNER_OF')
+            return {'table': resources}
+
+        except NotFoundException:
+            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+
+        except Exception:
+            return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def put(self, table_uri: str, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        try:
+            self.neo4j.add_owner(table_uri=table_uri,
+                                 owner=user_id)
+            return {'message': 'The owner {} for table_uri {} '
+                               'is added successfully'.format(user_id,
+                                                              table_uri)}, HTTPStatus.OK
+        except Exception as e:
+            return {'message': 'The owner {} for table_uri {} '
+                               'is not added successfully'.format(user_id,
+                                                                  table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def delete(self, table_uri: str, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        try:
+            self.neo4j.delete_owner(table_uri=table_uri,
+                                    owner=user_id)
+            return {'message': 'The owner {} for table_uri {} '
+                               'is deleted successfully'.format(user_id,
+                                                                table_uri)}, HTTPStatus.OK
+        except Exception:
+            return {'message': 'The owner {} for table_uri {} '
+                               'is not deleted successfully'.format(user_id,
+                                                                    table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+class UserReadAPI(Resource):
+    """
+    Build get / put API to support user bookmark resource features.
+    It will create a relationship(read / read_by) between user and resources(table, dashboard etc)
+    """
+
+    def __init__(self) -> None:
+        self.neo4j = neo4j_proxy.get_neo4j()
+
+    def get(self, user_id: str) -> Tuple:
+        """
+        Return a list of resources that user has read
+
+        :param user_id:
+        :return:
+        """
+        try:
+            resources = self.neo4j.get_resources_by_user_relation(user_id=user_id,
+                                                                  relation='READ')
+            return {'table': resources}
+
+        except NotFoundException:
+            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+
+        except Exception:
+            return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def put(self, user_id: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+        """
+        Create the relationship between user and resources.
+        todo: It will need to refactor all neo4j proxy api to take a type argument.
+
+        :param user_id:
+        :param table_uri:
+        :return:
+        """
+        try:
+            self.neo4j.add_resource_relation_by_user(table_uri=table_uri,
+                                                     user=user_id,
+                                                     relation='READ',
+                                                     reverse_relation='READ_BY')
+            return {'message': 'The user {} for table_uri {} '
+                               'is added successfully'.format(user_id,
+                                                              table_uri)}, HTTPStatus.OK
+        except Exception as e:
+            return {'message': 'The user {} for table_uri {} '
+                               'is not added successfully'.format(user_id,
+                                                                  table_uri)}, \
+                   HTTPStatus.INTERNAL_SERVER_ERROR
+
+    def delete(self, table_uri: str, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+        """
+        Delete the relationship between user and resources.
+        todo: It will need to refactor all neo4j proxy api to take a type argument.
+
+        :param user_id:
+        :param table_uri:
+        :return:
+        """
+        try:
+            self.neo4j.delete_resource_relation_by_user(table_uri=table_uri,
+                                                        user=user_id,
+                                                        relation='READ',
+                                                        reverse_relation='READ_BY')
+            return {'message': 'The user {} for table_uri {} '
+                               'is added successfully'.format(user_id,
+                                                              table_uri)}, HTTPStatus.OK
+        except Exception as e:
+            return {'message': 'The user {} for table_uri {} '
+                               'is not added successfully'.format(user_id,
+                                                                  table_uri)}, \
+                   HTTPStatus.INTERNAL_SERVER_ERROR

--- a/metadata_service/util.py
+++ b/metadata_service/util.py
@@ -1,0 +1,4 @@
+from collections import namedtuple
+
+
+UserResourceRel = namedtuple('UserResourceRel', 'follow, own, read')

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ format = pylint
 exclude = .svc,CVS,.bzr,.hg,.git,__pycache__,venv
 max-complexity = 10
 max-line-length = 120
-ignore = I201,W503
+ignore = I201,W503,E999
 
 [pep8]
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 setup(
     name='amundsen-metadata',

--- a/tests/unit/test_neo4j_proxy.py
+++ b/tests/unit/test_neo4j_proxy.py
@@ -12,6 +12,7 @@ from metadata_service.entity.table_detail import Application, Column, Table, Tag
     Statistics, User
 from metadata_service.entity.tag_detail import TagDetail
 from metadata_service.proxy.neo4j_proxy import Neo4jProxy
+from metadata_service.util import UserResourceRel
 
 
 class TestNeo4jProxy(unittest.TestCase):
@@ -503,8 +504,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                               source_type='github'))
 
             neo4j_proxy = Neo4jProxy(endpoint='bogus')
-            result = neo4j_proxy.get_resources_by_user_relation(user_id='test_user',
-                                                                relation='follow')
+            result = neo4j_proxy.get_table_by_user_relation(user_email='test_user',
+                                                            relation_type=UserResourceRel.follow)
             self.assertEqual(len(result['table']), 1)
             self.assertEqual(result['table'][0].name, 'foo_table')
 
@@ -522,10 +523,9 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_transaction.commit = mock_commit
 
             neo4j_proxy = Neo4jProxy(endpoint='bogus')
-            neo4j_proxy.add_resource_relation_by_user(table_uri='dummy_uri',
-                                                      user='tester',
-                                                      relation='follow',
-                                                      reverse_relation='reverse_relation')
+            neo4j_proxy.add_table_relation_by_user(table_uri='dummy_uri',
+                                                   user_email='tester',
+                                                   relation_type=UserResourceRel.follow)
             self.assertEquals(mock_run.call_count, 2)
             self.assertEquals(mock_commit.call_count, 1)
 
@@ -543,10 +543,9 @@ class TestNeo4jProxy(unittest.TestCase):
             mock_transaction.commit = mock_commit
 
             neo4j_proxy = Neo4jProxy(endpoint='bogus')
-            neo4j_proxy.delete_resource_relation_by_user(table_uri='dummy_uri',
-                                                         user='tester',
-                                                         relation='follow',
-                                                         reverse_relation='reverse_relation')
+            neo4j_proxy.delete_table_relation_by_user(table_uri='dummy_uri',
+                                                      user_email='tester',
+                                                      relation_type=UserResourceRel.follow)
             self.assertEquals(mock_run.call_count, 1)
             self.assertEquals(mock_commit.call_count, 1)
 

--- a/tests/unit/test_neo4j_proxy.py
+++ b/tests/unit/test_neo4j_proxy.py
@@ -14,7 +14,7 @@ from metadata_service.entity.tag_detail import TagDetail
 from metadata_service.proxy.neo4j_proxy import Neo4jProxy
 
 
-class TestGetTable(unittest.TestCase):
+class TestNeo4jProxy(unittest.TestCase):
 
     def setUp(self) -> None:
         self.app = create_app(config_module_class='metadata_service.config.LocalConfig')
@@ -450,6 +450,105 @@ class TestGetTable(unittest.TestCase):
             neo4j_proxy = Neo4jProxy(endpoint='bogus')
             neo4j_user = neo4j_proxy.get_user_detail(user_id='test_email')
             self.assertEquals(neo4j_user.email, 'test_email')
+
+    def test_get_resources_by_user_relation(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), \
+            patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute, \
+                patch.object(Neo4jProxy, 'get_table') as mock_get_table:
+
+            mock_execute.return_value.single.return_value = {
+                'table_records': [
+                    {
+                        'key': 'table_uri',
+
+                    }
+                ]
+            }
+            mock_get_table.return_value = Table(database='hive',
+                                                cluster='gold',
+                                                schema='foo_schema',
+                                                name='foo_table',
+                                                tags=[Tag(tag_name='test', tag_type='default')],
+                                                table_readers=[], description='foo description',
+                                                watermarks=[Watermark(watermark_type='high_watermark',
+                                                                      partition_key='ds',
+                                                                      partition_value='fake_value',
+                                                                      create_time='fake_time'),
+                                                            Watermark(watermark_type='low_watermark',
+                                                                      partition_key='ds',
+                                                                      partition_value='fake_value',
+                                                                      create_time='fake_time')],
+                                                columns=[Column(name='bar_id_1',
+                                                                description='bar col description',
+                                                                col_type='varchar',
+                                                                sort_order=0, stats=[Statistics(start_epoch=1,
+                                                                                                end_epoch=1,
+                                                                                                stat_type='avg',
+                                                                                                stat_val='1')]),
+                                                         Column(name='bar_id_2',
+                                                                description='bar col2 description',
+                                                                col_type='bigint',
+                                                                sort_order=1, stats=[Statistics(start_epoch=2,
+                                                                                                end_epoch=2,
+                                                                                                stat_type='avg',
+                                                                                                stat_val='2')])],
+                                                owners=[User(email='tester@lyft.com')],
+                                                table_writer=Application(
+                                                    application_url=self.table_writer['application_url'],
+                                                    description=self.table_writer['description'],
+                                                    name=self.table_writer['name'],
+                                                    id=self.table_writer['id']),
+                                                last_updated_timestamp=1,
+                                                source=Source(source='/source_file_loc',
+                                                              source_type='github'))
+
+            neo4j_proxy = Neo4jProxy(endpoint='bogus')
+            result = neo4j_proxy.get_resources_by_user_relation(user_id='test_user',
+                                                                relation='follow')
+            self.assertEqual(len(result['table']), 1)
+            self.assertEqual(result['table'][0].name, 'foo_table')
+
+    def test_add_resource_relation_by_user(self) -> None:
+        with patch.object(GraphDatabase, 'driver') as mock_driver:
+            mock_session = MagicMock()
+            mock_driver.return_value.session.return_value = mock_session
+
+            mock_transaction = MagicMock()
+            mock_session.begin_transaction.return_value = mock_transaction
+
+            mock_run = MagicMock()
+            mock_transaction.run = mock_run
+            mock_commit = MagicMock()
+            mock_transaction.commit = mock_commit
+
+            neo4j_proxy = Neo4jProxy(endpoint='bogus')
+            neo4j_proxy.add_resource_relation_by_user(table_uri='dummy_uri',
+                                                      user='tester',
+                                                      relation='follow',
+                                                      reverse_relation='reverse_relation')
+            self.assertEquals(mock_run.call_count, 2)
+            self.assertEquals(mock_commit.call_count, 1)
+
+    def test_delete_resource_relation_by_user(self) -> None:
+        with patch.object(GraphDatabase, 'driver') as mock_driver:
+            mock_session = MagicMock()
+            mock_driver.return_value.session.return_value = mock_session
+
+            mock_transaction = MagicMock()
+            mock_session.begin_transaction.return_value = mock_transaction
+
+            mock_run = MagicMock()
+            mock_transaction.run = mock_run
+            mock_commit = MagicMock()
+            mock_transaction.commit = mock_commit
+
+            neo4j_proxy = Neo4jProxy(endpoint='bogus')
+            neo4j_proxy.delete_resource_relation_by_user(table_uri='dummy_uri',
+                                                         user='tester',
+                                                         relation='follow',
+                                                         reverse_relation='reverse_relation')
+            self.assertEquals(mock_run.call_count, 1)
+            self.assertEquals(mock_commit.call_count, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Test locally with staging data which works:

action in { own, follow, read}
```
curl http://localhost:5000/user/tfeng@lyft.com/action/
curl -v -x PUT http://localhost:5000/user/tfeng@lyft.com/action/hive%3A%2F%2Fgold.default%2Ftable_name
curl -v -x DELETE http://localhost:5000/user/tfeng@lyft.com/action/hive%3A%2F%2Fgold.default%2Ftable_name
```

todo:
1. will create a separate pr to refactor existing table_owner endpoint to use the new generic endpoint.
2. currently it doesn't take type as url input parameter which requires larger refactor. I plan to do(create a ticket) once we have the dashboard feature coming in.

Design qq:
1. do we need to support put/delete for read or user API?
2. do we need to allow FE to pass a threshold to the read API endpoint? Currently based on staging data, I read / use 28 tables which I am not sure if we want to display all of them.