### PR TITLE
Table Detail APIs improvements

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -1,12 +1,13 @@
 import logging
 import re
-from typing import Union, List, Dict, Any
+from typing import Union, List, Dict, Any, Tuple
 
 from atlasclient.client import Atlas
 from atlasclient.exceptions import BadRequest
+from metadata_service.entity.tag_detail import TagDetail
 
 from metadata_service.entity.popular_table import PopularTable
-from metadata_service.entity.table_detail import Table
+from metadata_service.entity.table_detail import Table, User, Tag
 from metadata_service.entity.user_detail import User as UserEntity
 from metadata_service.exception import NotFoundException
 from metadata_service.proxy import BaseProxy
@@ -18,6 +19,7 @@ LOGGER = logging.getLogger(__name__)
 class AtlasProxy(BaseProxy):
     """
     Atlas Proxy client for the amundsen metadata
+    {ATLAS_API_DOCS} = https://atlas.apache.org/api/v2/
     """
     TABLE_ENTITY = 'Table'
     DB_KEY = 'db'
@@ -72,37 +74,61 @@ class AtlasProxy(BaseProxy):
         result = pattern.match(table_uri)
         return result.groupdict() if result else dict()
 
-    def get_user_detail(self, *, user_id: str) -> Union[UserEntity, None]:
-        pass
-
-    def get_table(self, *, table_uri: str) -> Table:
+    def _get_table_entity(self, *, table_uri: str) -> Tuple:
         """
-        Gathers all the information needed for the Table Detail Page.
-        It tries to get the table information from
+        Fetch information from table_uri and then find the appropriate entity
+        The reason, we're not returning the entity_unique_attribute().entity
+        directly is because the entity_unique_attribute() return entity Object
+        that can be used for update purposes,
+        while entity_unique_attribute().entity only returns the dictionary
         :param table_uri:
         :return:
         """
         table_info = self._extract_info_from_uri(table_uri=table_uri)
 
         try:
-            # The reason to use the DATASET_ENTITY here instead of TABLE_ENTITY
-            # is to access the older data (if any) which was generated before
-            # introducing the TABLE_ENTITY in atlas.
-            entity = self._driver.entity_unique_attribute(
+            return self._driver.entity_unique_attribute(
                 table_info['entity'],
-                qualifiedName=table_info.get('name')).entity
+                qualifiedName=table_info.get('name')), table_info
         except Exception as ex:
             LOGGER.exception('Table not found. {}'.format(str(ex)))
             raise NotFoundException('Table URI( {table_uri} ) does not exist'
                                     .format(table_uri=table_uri))
 
+    def get_user_detail(self, *, user_id: str) -> Union[UserEntity, None]:
+        pass
+
+    def get_table(self, *, table_uri: str) -> Table:
+        """
+        Gathers all the information needed for the Table Detail Page.
+        :param table_uri:
+        :return:
+        """
+        entity, table_info = self._get_table_entity(table_uri=table_uri)
+        table_details = entity.entity
+
         try:
+            attrs = table_details['attributes']
+            rel_attrs = table_details['relationshipAttributes']
+
+            tags = []
+            for classification in table_details.get("classifications", list()):
+                tags.append(
+                    Tag(
+                        tag_name=classification.get('typeName'),
+                        tag_type=classification.get('typeName')
+                    )
+                )
+
             table = Table(database=table_info['entity'],
                           cluster=table_info['cluster'],
                           schema=table_info['db'],
                           name=table_info['name'],
-                          columns=entity['relationshipAttributes']['columns'],
-                          last_updated_timestamp=entity['updateTime'])
+                          tags=tags,
+                          description=attrs.get('description'),
+                          owners=[User(email=attrs.get('owner'))],
+                          columns=rel_attrs.get('columns'),
+                          last_updated_timestamp=table_details.get('updateTime'))
 
             return table
         except KeyError as ex:
@@ -116,22 +142,68 @@ class AtlasProxy(BaseProxy):
         pass
 
     def add_owner(self, *, table_uri: str, owner: str) -> None:
-        pass
+        """
+        It simply replaces the owner field in atlas with the new string.
+        FixMe (Verdan): Implement multiple data owners and
+        atlas changes in the documentation if needed to make owner field a list
+        :param table_uri:
+        :param owner: Email address of the owner
+        :return: None, as it simply adds the owner.
+        """
+        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity.entity['attributes']['owner'] = owner
+        entity.update()
 
     def get_table_description(self, *,
                               table_uri: str) -> Union[str, None]:
-        pass
+        """
+        :param table_uri:
+        :return: The description of the table as a string
+        """
+        entity, _ = self._get_table_entity(table_uri=table_uri)
+        return entity.entity['attributes']['description']
 
     def put_table_description(self, *,
                               table_uri: str,
                               description: str) -> None:
-        pass
+        """
+        Update the description of the given table.
+        :param table_uri:
+        :param description: Description string
+        :return: None
+        """
+        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity.entity['attributes']['description'] = description
+        entity.update()
 
     def add_tag(self, *, table_uri: str, tag: str) -> None:
-        pass
+        """
+        Assign the tag/classification to the give table
+        API Ref: /resource_EntityREST.html#resource_EntityREST_addClassification_POST
+        :param table_uri:
+        :param tag: Tag/Classfification Name
+        :return: None
+        """
+        entity, _ = self._get_table_entity(table_uri=table_uri)
+        entity_bulk_tag = {"classification": {"typeName": tag},
+                           "entityGuids": [entity.entity['guid']]}
+        self._driver.entity_bulk_classification.create(data=entity_bulk_tag)
 
     def delete_tag(self, *, table_uri: str, tag: str) -> None:
-        pass
+        """
+        Delete the assigned classfication/tag from the given table
+        API Ref: /resource_EntityREST.html#resource_EntityREST_deleteClassification_DELETE
+        :param table_uri:
+        :param tag:
+        :return:
+        """
+        try:
+            entity, _ = self._get_table_entity(table_uri=table_uri)
+            guid_entity = self._driver.entity_guid(entity.entity['guid'])
+            guid_entity.classifications(tag).delete()
+        except Exception as ex:
+            LOGGER.exception('For some reason this deletes the classification '
+                             'but also always return exception. {}'.format(str(ex)))
 
     def put_column_description(self, *,
                                table_uri: str,
@@ -165,7 +237,8 @@ class AtlasProxy(BaseProxy):
                 # Fix: https://github.com/jpoullet2000/atlasclient/pull/60
                 database = attrs.get(self.DB_KEY)
                 if database:
-                    db_attrs = self._driver.entity_guid(database['guid']).entity['attributes']
+                    db_entity = self._driver.entity_guid(database['guid'])
+                    db_attrs = db_entity.entity['attributes']
                     db_name = db_attrs.get(self.NAME_KEY)
                     db_cluster = db_attrs.get('clusterName')
                 else:
@@ -184,7 +257,21 @@ class AtlasProxy(BaseProxy):
         pass
 
     def get_tags(self) -> List:
-        pass
+        """
+        Fetch all the classification entity definitions from atlas  as this
+        will be used to generate the autocomplete on the table detail page
+        :return: A list of TagDetail Objects
+        """
+        tags = []
+        for type_def in self._driver.typedefs:
+            for classification in type_def.classificationDefs:
+                tags.append(
+                    TagDetail(
+                        tag_name=classification.name,
+                        tag_count=0     # FixMe (Verdan): Implement the tag count
+                    )
+                )
+        return tags
 
     def get_table_by_user_relation(self, *, user_email: str,
                                    relation_type: UserResourceRel) -> Dict[str, Any]:

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -4,6 +4,8 @@ from typing import Union, List, Dict, Any, Tuple
 
 from atlasclient.client import Atlas
 from atlasclient.exceptions import BadRequest
+from atlasclient.models import EntityUniqueAttribute
+
 from metadata_service.entity.tag_detail import TagDetail
 
 from metadata_service.entity.popular_table import PopularTable
@@ -74,7 +76,7 @@ class AtlasProxy(BaseProxy):
         result = pattern.match(table_uri)
         return result.groupdict() if result else dict()
 
-    def _get_table_entity(self, *, table_uri: str) -> Tuple:
+    def _get_table_entity(self, *, table_uri: str) -> Tuple[EntityUniqueAttribute, Dict]:
         """
         Fetch information from table_uri and then find the appropriate entity
         The reason, we're not returning the entity_unique_attribute().entity
@@ -116,7 +118,7 @@ class AtlasProxy(BaseProxy):
                 tags.append(
                     Tag(
                         tag_name=classification.get('typeName'),
-                        tag_type=classification.get('typeName')
+                        tag_type="default"
                     )
                 )
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.3'
+__version__ = '1.0.4'
 
 # Dependencies to make Amundsen work with Apache Atlas
 atlas = ['atlasclient>=0.1.2']

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.4'
+__version__ = '1.0.3'
 
 # Dependencies to make Amundsen work with Apache Atlas
 atlas = ['atlasclient>=0.1.2']

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -1,10 +1,11 @@
 import unittest
 
 from atlasclient.exceptions import BadRequest
+from metadata_service.entity.tag_detail import TagDetail
 from mock import patch, MagicMock
 
 from metadata_service.entity.popular_table import PopularTable
-from metadata_service.entity.table_detail import (Table)
+from metadata_service.entity.table_detail import (Table, User, Tag)
 from metadata_service.exception import NotFoundException
 from metadata_service.proxy.atlas_proxy import AtlasProxy
 
@@ -22,6 +23,12 @@ class TestAtlasProxy(unittest.TestCase):
         self.name = 'TEST_TABLE'
         self.table_uri = f'{self.entity_type}://{self.cluster}.{self.db}/{self.name}'
 
+        self.classification_entity = {
+            'classifications': [
+                {'typeName': 'PII_DATA', 'name': 'PII_DATA'},
+            ]
+        }
+
         entity1_relationships = {
             'relationshipAttributes': {
                 'columns': []
@@ -34,6 +41,8 @@ class TestAtlasProxy(unittest.TestCase):
             'attributes': {
                 'qualifiedName': 'Table1_Qualified',
                 'name': 'Table1',
+                'description': 'Dummy Description',
+                'owner': 'dummy@email.com',
                 'db': {
                     'guid': '-100',
                     'qualifiedName': self.db,
@@ -41,6 +50,7 @@ class TestAtlasProxy(unittest.TestCase):
                 }
             }
         }
+        self.entity1.update(self.classification_entity)
         self.entity1.update(entity1_relationships)
         self.entity1['attributes'].update(entity1_relationships)
 
@@ -56,6 +66,8 @@ class TestAtlasProxy(unittest.TestCase):
             'attributes': {
                 'qualifiedName': 'Table2_Qualified',
                 'name': 'Table1',
+                'description': 'Dummy Description',
+                'owner': 'dummy@email.com',
                 'db': {
                     'guid': '-100',
                     'qualifiedName': self.db,
@@ -63,6 +75,7 @@ class TestAtlasProxy(unittest.TestCase):
                 }
             }
         }
+        self.entity2.update(self.classification_entity)
         self.entity2.update(entity2_relationships)
         self.entity2['attributes'].update(entity2_relationships)
 
@@ -72,6 +85,17 @@ class TestAtlasProxy(unittest.TestCase):
                 self.entity2,
             ]
         }
+
+    def _mock_get_table_entity(self, entity=None):
+        mocked_entity = MagicMock()
+        mocked_entity.entity = entity or self.entity1
+        self.proxy._get_table_entity = MagicMock(return_value=(mocked_entity, {
+            'entity': self.entity_type,
+            'cluster': self.cluster,
+            'db': self.db,
+            'name': self.name
+        }))
+        return mocked_entity
 
     def test_extract_table_uri_info(self):
         table_info = self.proxy._extract_info_from_uri(table_uri=self.table_uri)
@@ -91,18 +115,34 @@ class TestAtlasProxy(unittest.TestCase):
         expected = ['1', '2']
         self.assertListEqual(response, expected)
 
-    def test_get_table(self):
+    def test_get_table_entity(self):
         unique_attr_response = MagicMock()
-        unique_attr_response.entity = self.entity1
 
         self.proxy._driver.entity_unique_attribute = MagicMock(
             return_value=unique_attr_response)
+        ent, table_info = self.proxy._get_table_entity(table_uri=self.table_uri)
+        self.assertDictEqual(table_info, {
+            'entity': self.entity_type,
+            'cluster': self.cluster,
+            'db': self.db,
+            'name': self.name
+        })
+        self.assertEqual(ent.__repr__(), unique_attr_response.__repr__())
+
+    def test_get_table(self):
+        self._mock_get_table_entity()
         response = self.proxy.get_table(table_uri=self.table_uri)
+
+        classif_name = self.classification_entity['classifications'][0]['typeName']
+        ent_attrs = self.entity1['attributes']
 
         expected = Table(database=self.entity_type,
                          cluster=self.cluster,
                          schema=self.db,
                          name=self.name,
+                         tags=[Tag(tag_name=classif_name, tag_type=classif_name)],
+                         description=ent_attrs['description'],
+                         owners=[User(email=ent_attrs['owner'])],
                          columns=self.entity1['relationshipAttributes']['columns'],
                          last_updated_timestamp=self.entity1['updateTime'])
         self.assertEqual(str(expected), str(response))
@@ -146,12 +186,14 @@ class TestAtlasProxy(unittest.TestCase):
         self.proxy._driver.entity_guid = MagicMock(return_value=db_entity)
 
         response = self.proxy.get_popular_tables(num_entries=2)
+        ent1_attrs = self.entity1['attributes']
+        ent2_attrs = self.entity2['attributes']
 
         expected = [
             PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
-                         name=self.entity1['attributes']['qualifiedName']),
+                         name=ent1_attrs['qualifiedName'], description=ent1_attrs['description']),
             PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
-                         name=self.entity2['attributes']['qualifiedName']),
+                         name=ent2_attrs['qualifiedName'], description=ent1_attrs['description']),
         ]
 
         self.assertEqual(response.__repr__(), expected.__repr__())
@@ -176,14 +218,69 @@ class TestAtlasProxy(unittest.TestCase):
         self.proxy._driver.entity_bulk = MagicMock(return_value=[bulk_ent_collection])
         response = self.proxy.get_popular_tables(num_entries=2)
 
+        ent1_attrs = self.entity1['attributes']
+        ent2_attrs = self.entity2['attributes']
+
         expected = [
             PopularTable(database=self.entity_type, cluster='', schema='',
-                         name=self.entity1['attributes']['qualifiedName']),
+                         name=ent1_attrs['qualifiedName'], description=ent1_attrs['description']),
             PopularTable(database=self.entity_type, cluster='', schema='',
-                         name=self.entity2['attributes']['qualifiedName']),
+                         name=ent2_attrs['qualifiedName'], description=ent1_attrs['description']),
         ]
 
         self.assertEqual(response.__repr__(), expected.__repr__())
+
+    def test_get_table_description(self):
+        self._mock_get_table_entity()
+        response = self.proxy.get_table_description(table_uri=self.table_uri)
+        self.assertEqual(response, self.entity1['attributes']['description'])
+
+    def test_put_table_description(self):
+        self._mock_get_table_entity()
+        self.proxy.put_table_description(table_uri=self.table_uri,
+                                         description="DOESNT_MATTER")
+
+    def test_get_tags(self):
+        name = "DUMMY_CLASSIFICATION"
+        mocked_classif = MagicMock()
+        mocked_classif.name = name
+
+        mocked_def = MagicMock()
+        mocked_def.classificationDefs = [mocked_classif]
+
+        self.proxy._driver.typedefs = [mocked_def]
+
+        response = self.proxy.get_tags()
+
+        expected = [TagDetail(tag_name=name, tag_count=0)]
+        self.assertEqual(response.__repr__(), expected.__repr__())
+
+    def test_add_tag(self):
+        tag = "TAG"
+        self._mock_get_table_entity()
+
+        with patch.object(self.proxy._driver.entity_bulk_classification, 'create') as mock_execute:
+            self.proxy.add_tag(table_uri=self.table_uri, tag=tag)
+            mock_execute.assert_called_with(
+                data={'classification': {'typeName': tag}, 'entityGuids': [self.entity1['guid']]}
+            )
+
+    def test_delete_tag(self):
+        tag = "TAG"
+        self._mock_get_table_entity()
+        mocked_entity = MagicMock()
+        self.proxy._driver.entity_guid = MagicMock(return_value=mocked_entity)
+
+        with patch.object(mocked_entity.classifications(tag), 'delete') as mock_execute:
+            self.proxy.delete_tag(table_uri=self.table_uri, tag=tag)
+            mock_execute.assert_called_with()
+
+    def test_add_owner(self):
+        owner = "OWNER"
+        entity = self._mock_get_table_entity()
+        with patch.object(entity, 'update') as mock_execute:
+            self.proxy.add_owner(table_uri=self.table_uri, owner=owner)
+            mock_execute.assert_called_with()
 
 
 if __name__ == '__main__':

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -140,7 +140,7 @@ class TestAtlasProxy(unittest.TestCase):
                          cluster=self.cluster,
                          schema=self.db,
                          name=self.name,
-                         tags=[Tag(tag_name=classif_name, tag_type=classif_name)],
+                         tags=[Tag(tag_name=classif_name, tag_type="default")],
                          description=ent_attrs['description'],
                          owners=[User(email=ent_attrs['owner'])],
                          columns=self.entity1['relationshipAttributes']['columns'],


### PR DESCRIPTION
This PR extends the functionality of Apache Atlas, and using existing attributes of Atlas, it implements the owner, description, and tags functionality on the detail pages. 
Added Todos and FixMe's where needed for now. 

FYI: @feng-tao @jinhyukchang