### PR TITLE
gitignore /dist folder avoids :egg:s in commits!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,11 @@
 *.egg-info
 .*.swp
 .DS_Store
+build/
+dist/
 venv/
 venv3/
 .cache/
-build/
 .idea/
 .coverage
 .mypy_cache


### PR DESCRIPTION
As discussed in https://github.com/lyft/amundsenmetadatalibrary/pull/27#issuecomment-486065064

I plan to follow up with changes as needed to bring the 3 other `lyft/amundsen*` repos on par.