### PR TITLE
add is_view field to TableDetailAPI payload

### DIFF
--- a/metadata_service/api/table.py
+++ b/metadata_service/api/table.py
@@ -76,7 +76,8 @@ table_detail_fields = {
     'watermarks': fields.List(fields.Nested(watermark_fields)),
     'table_writer': fields.Nested(table_writer_fields),  # Optional
     'last_updated_timestamp': fields.Integer,  # Optional
-    'source': fields.Nested(source_fields)  # Optional
+    'source': fields.Nested(source_fields),  # Optional
+    'is_view': fields.Boolean  # Optional
 }
 
 

--- a/metadata_service/entity/table_detail.py
+++ b/metadata_service/entity/table_detail.py
@@ -137,14 +137,15 @@ class Table:
                  schema: str,
                  name: str,
                  tags: Iterable[Tag] =(),
-                 table_readers: Iterable[Reader] =(),
-                 description: Optional[str] =None,
+                 table_readers: Iterable[Reader] = (),
+                 description: Optional[str] = None,
                  columns: Iterable[Column],
-                 owners: Iterable[User] =(),
-                 watermarks: Iterable[Watermark] =(),
-                 table_writer: Optional[Application] =None,
+                 owners: Iterable[User] = (),
+                 watermarks: Iterable[Watermark] = (),
+                 table_writer: Optional[Application] = None,
                  last_updated_timestamp: Optional[int],
-                 source: Optional[Source] = None
+                 source: Optional[Source] = None,
+                 is_view: Optional[bool] = None,
                  ) -> None:
 
         self.database = database
@@ -160,13 +161,15 @@ class Table:
         self.table_writer = table_writer
         self.last_updated_timestamp = last_updated_timestamp
         self.source = source
+        self.is_view = is_view or False
 
     def __repr__(self) -> str:
         return """Table(database={!r}, cluster={!r}, schema={!r}, name={!r}, tags={!r}, table_readers={!r},
                         description={!r}, columns={!r}, owners={!r}, watermarks={!r}, table_writer={!r},
-                        last_updated_timestamp={!r}, source={!r})"""\
+                        last_updated_timestamp={!r}, source={!r}, is_view={!r})"""\
             .format(self.database, self.cluster,
                     self.schema, self.name, self.tags,
                     self.table_readers, self.description,
                     self.columns, self.owners, self.watermarks,
-                    self.table_writer, self.last_updated_timestamp, self.source)
+                    self.table_writer, self.last_updated_timestamp,
+                    self.source, self.is_view)

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -69,10 +69,6 @@ class Neo4jProxy(BaseProxy):
 
         wmk_results, table_writer, timestamp_value, owners, tags, source = self._exec_table_query(table_uri)
 
-        # neo4j returns is_view (boolean data type) as str, so we need to convert it to bool
-        is_view = self._safe_get(last_neo4j_record, 'tbl', 'is_view')
-        is_view = is_view.lower() in ['t', 'true'] if is_view else False
-
         table = Table(database=last_neo4j_record['db']['name'],
                       cluster=last_neo4j_record['clstr']['name'],
                       schema=last_neo4j_record['schema']['name'],
@@ -86,7 +82,7 @@ class Neo4jProxy(BaseProxy):
                       table_writer=table_writer,
                       last_updated_timestamp=timestamp_value,
                       source=source,
-                      is_view=is_view)
+                      is_view=self._safe_get(last_neo4j_record, 'tbl', 'is_view'))
 
         return table
 
@@ -238,7 +234,7 @@ class Neo4jProxy(BaseProxy):
         """
         for key in keys:
             dct = dct.get(key)
-            if not dct:
+            if dct is None:
                 return None
         return dct
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -81,7 +81,8 @@ class Neo4jProxy(BaseProxy):
                       watermarks=wmk_results,
                       table_writer=table_writer,
                       last_updated_timestamp=timestamp_value,
-                      source=source)
+                      source=source,
+                      is_view=last_neo4j_record['tbl']['is_view'])
 
         return table
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -70,6 +70,9 @@ class Neo4jProxy(BaseProxy):
         wmk_results, table_writer, timestamp_value, owners, tags, source = self._exec_table_query(table_uri)
 
         # neo4j returns is_view (boolean data type) as str, so we need to convert it to bool
+        is_view = self._safe_get(last_neo4j_record, 'tbl', 'is_view')
+        is_view = is_view.lower() in ['t', 'true'] if is_view else False
+
         table = Table(database=last_neo4j_record['db']['name'],
                       cluster=last_neo4j_record['clstr']['name'],
                       schema=last_neo4j_record['schema']['name'],
@@ -83,7 +86,7 @@ class Neo4jProxy(BaseProxy):
                       table_writer=table_writer,
                       last_updated_timestamp=timestamp_value,
                       source=source,
-                      is_view=self._safe_get(last_neo4j_record, 'tbl', 'is_view').lower() in ['t', 'true'])
+                      is_view=is_view)
 
         return table
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -82,7 +82,7 @@ class Neo4jProxy(BaseProxy):
                       table_writer=table_writer,
                       last_updated_timestamp=timestamp_value,
                       source=source,
-                      is_view=last_neo4j_record['tbl']['is_view'])
+                      is_view=self._safe_get(last_neo4j_record, 'tbl', 'is_view'))
 
         return table
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -69,6 +69,7 @@ class Neo4jProxy(BaseProxy):
 
         wmk_results, table_writer, timestamp_value, owners, tags, source = self._exec_table_query(table_uri)
 
+        # neo4j returns is_view (boolean data type) as str, so we need to convert it to bool
         table = Table(database=last_neo4j_record['db']['name'],
                       cluster=last_neo4j_record['clstr']['name'],
                       schema=last_neo4j_record['schema']['name'],
@@ -82,7 +83,7 @@ class Neo4jProxy(BaseProxy):
                       table_writer=table_writer,
                       last_updated_timestamp=timestamp_value,
                       source=source,
-                      is_view=self._safe_get(last_neo4j_record, 'tbl', 'is_view'))
+                      is_view=self._safe_get(last_neo4j_record, 'tbl', 'is_view').lower() in ['t', 'true'])
 
         return table
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.4'
+__version__ = '1.0.5'
 
 
 setup(

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -28,8 +28,7 @@ class TestNeo4jProxy(unittest.TestCase):
                        'schema': {
                            'name': 'foo_schema'},
                        'tbl': {
-                           'name': 'foo_table',
-                           'is_view': False},
+                           'name': 'foo_table'},
                        'tbl_dscrpt': {
                            'description': 'foo description'}
                        }
@@ -148,6 +147,50 @@ class TestNeo4jProxy(unittest.TestCase):
                              last_updated_timestamp=1,
                              source=Source(source='/source_file_loc',
                                            source_type='github'))
+
+            self.assertEqual(str(expected), str(table))
+
+    def test_get_table_view_only(self) -> None:
+        col_usage_return_value = copy.deepcopy(self.col_usage_return_value)
+        for col in col_usage_return_value:
+            col['tbl']['is_view'] = True
+
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            mock_execute.side_effect = [col_usage_return_value, [], self.table_level_return_value]
+
+            neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
+            table = neo4j_proxy.get_table(table_uri='dummy_uri')
+
+            expected = Table(database='hive', cluster='gold', schema='foo_schema', name='foo_table',
+                             tags=[Tag(tag_name='test', tag_type='default')],
+                             table_readers=[], description='foo description',
+                             watermarks=[Watermark(watermark_type='high_watermark',
+                                                   partition_key='ds',
+                                                   partition_value='fake_value',
+                                                   create_time='fake_time'),
+                                         Watermark(watermark_type='low_watermark',
+                                                   partition_key='ds',
+                                                   partition_value='fake_value',
+                                                   create_time='fake_time')],
+                             columns=[Column(name='bar_id_1', description='bar col description', col_type='varchar',
+                                             sort_order=0, stats=[Statistics(start_epoch=1,
+                                                                             end_epoch=1,
+                                                                             stat_type='avg',
+                                                                             stat_val='1')]),
+                                      Column(name='bar_id_2', description='bar col2 description', col_type='bigint',
+                                             sort_order=1, stats=[Statistics(start_epoch=2,
+                                                                             end_epoch=2,
+                                                                             stat_type='avg',
+                                                                             stat_val='2')])],
+                             owners=[User(email='tester@lyft.com')],
+                             table_writer=Application(application_url=self.table_writer['application_url'],
+                                                      description=self.table_writer['description'],
+                                                      name=self.table_writer['name'],
+                                                      id=self.table_writer['id']),
+                             last_updated_timestamp=1,
+                             source=Source(source='/source_file_loc',
+                                           source_type='github'),
+                             is_view=True)
 
             self.assertEqual(str(expected), str(table))
 

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -146,7 +146,8 @@ class TestNeo4jProxy(unittest.TestCase):
                                                       id=self.table_writer['id']),
                              last_updated_timestamp=1,
                              source=Source(source='/source_file_loc',
-                                           source_type='github'))
+                                           source_type='github'),
+                             is_view=False)
 
             self.assertEqual(str(expected), str(table))
 

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -28,7 +28,8 @@ class TestNeo4jProxy(unittest.TestCase):
                        'schema': {
                            'name': 'foo_schema'},
                        'tbl': {
-                           'name': 'foo_table'},
+                           'name': 'foo_table',
+                           'is_view': False},
                        'tbl_dscrpt': {
                            'description': 'foo description'}
                        }

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -154,7 +154,7 @@ class TestNeo4jProxy(unittest.TestCase):
     def test_get_table_view_only(self) -> None:
         col_usage_return_value = copy.deepcopy(self.col_usage_return_value)
         for col in col_usage_return_value:
-            col['tbl']['is_view'] = True
+            col['tbl']['is_view'] = 'True'
 
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             mock_execute.side_effect = [col_usage_return_value, [], self.table_level_return_value]

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -154,7 +154,7 @@ class TestNeo4jProxy(unittest.TestCase):
     def test_get_table_view_only(self) -> None:
         col_usage_return_value = copy.deepcopy(self.col_usage_return_value)
         for col in col_usage_return_value:
-            col['tbl']['is_view'] = 'True'
+            col['tbl']['is_view'] = True
 
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             mock_execute.side_effect = [col_usage_return_value, [], self.table_level_return_value]


### PR DESCRIPTION
This PR is to add `is_view` field to TableDetailAPI payload, so frontend can get the value and differentiate Views from Tables.