### PR TITLE
Describe and make easier Apache Atlas integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Amundsen Metadata service
-Amundsen Metadata service serves Restful API and responsible for providing and also updating metadata, such as table & column description, and tags. Metadata service is using Neo4j as a persistent layer.
+Amundsen Metadata service serves Restful API and responsible for providing and also updating metadata, such as table & column description, and tags. Metadata service can use Neo4j or Apache Atlas as a persistent layer.
 
 
 ## Requirements
@@ -58,6 +58,29 @@ For example, in order to have different config for production, you can inherit C
 `METADATA_SVC_CONFIG_MODULE_CLASS=metadata_service.config.ProdConfig`
 
 This way Metadata service will use production config in production environment. For more information on how the configuration is being loaded and used, here's reference from Flask [doc](http://flask.pocoo.org/docs/1.0/config/#development-production "doc").
+
+# Apache Atlas
+Amundsen Metadata service can use Apache Atlas as a backend. Some of the benefits of using Apache Atlas instead of Neo4j is that Apache Atlas offers plugins to several services (e.g. Apache Hive, Apache Spark) that allow for push based updates. It also allows to set policies on what metadata is accesible and editable by means of Apache Ranger.
+
+If you would like to use Apache Atlas as a backend for Metadata service you will need to create a [Config](https://github.com/lyft/amundsenmetadatalibrary/blob/master/metadata_service/config.py "Config") as mentioned above. Make sure to include the following:
+
+```python
+PROXY_CLIENT = PROXY_CLIENTS['ATLAS'] # or env PROXY_CLIENT='ATLAS'
+PROXY_PORT = 21000          # or env PROXY_PORT
+PROXY_USER = 'atlasuser'    # or env CREDENTIALS_PROXY_USER
+PROXY_PASSWORD = 'password' # or env CREDENTIALS_PROXY_PASSWORD
+```
+
+To start the service with Atlas from Docker. Make sure you have `atlasserver` configured in DNS (or docker-compose)
+
+```bash
+$ docker run -p 5000:5000 --env PROXY_CLIENT=ATLAS --env PROXY_PORT=21000 --env PROXY_HOST=atlasserver --env CREDENTIALS_PROXY_USER=atlasuser --env CREDENTIALS_PROXY_PASSWORD=password amundsen-metadata:latest
+```
+
+---
+**NOTE**
+
+The support for Apache Atlas is work in progress. For example, while Apache Atlas supports fine grained access, Amundsen does not support this yet. 
 
 # Developer guide
 ## Code style

--- a/metadata_service/__init__.py
+++ b/metadata_service/__init__.py
@@ -61,6 +61,7 @@ def create_app(*, config_module_class: str) -> Flask:
     logging.basicConfig(format=app.config.get('LOG_FORMAT'), datefmt=app.config.get('LOG_DATE_FORMAT'))
     logging.getLogger().setLevel(app.config.get('LOG_LEVEL'))
     logging.info('Created app with config name {}'.format(config_module_class))
+    logging.info('Using backend {}'.format(app.config.get('PROXY_CLIENT')))
 
     api_bp = Blueprint('api', __name__)
     api_bp.add_url_rule('/healthcheck', 'healthcheck', healthcheck)

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -36,4 +36,4 @@ class LocalConfig(Config):
 
     PROXY_HOST = os.environ.get('PROXY_HOST', f'bolt://{LOCAL_HOST}')
     PROXY_PORT = os.environ.get('PROXY_PORT', 7687)
-    PROXY_CLIENT = PROXY_CLIENTS['NEO4J']
+    PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'NEO4J')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,4 +56,4 @@ neo4j-driver==1.6.0
 neotime==1.0.0
 pytz==2018.4
 statsd==3.2.1
-atlasclient==0.1.4
+atlasclient==0.1.5


### PR DESCRIPTION
Updates the default config to take PROXY_CLIENT from the environment. This allows the docker image to use Apache Atlas without changes. 