### PR TITLE
Fix bug of latest_timestamp when data not available

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -620,7 +620,7 @@ class Neo4jProxy(BaseProxy):
                                             param_dict={})
         # None means we don't have record for neo4j, es last updated / index ts
         record = record.single()
-        return record['ts'].get('latest_timestmap')
+        return record.get('ts', {}).get('latest_timestmap', 0)
 
     @timer_with_counter
     @_CACHE.cache('_get_popular_tables_uris', _GET_POPULAR_TABLE_CACHE_EXPIRY_SEC)

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -444,7 +444,7 @@ class TestNeo4jProxy(unittest.TestCase):
             }
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
             neo4j_last_updated_ts = neo4j_proxy.get_latest_updated_ts()
-            self.assertIs(neo4j_last_updated_ts, None)
+            self.assertEqual(neo4j_last_updated_ts, 0)
 
     def test_get_popular_tables(self) -> None:
         # Test cache hit


### PR DESCRIPTION
Make sure you have checked **all** steps below.

### Title

- [ ] My PR Title addresses the issue accurately and concisely. 
    - Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:
Address this issue mentioned by OSS slack(https://amundsenworkspace.slack.com/archives/CHQERT0D7/p1556823283047700)

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does

### Code Quality & Coverage

- [ ] Passes `make test`