### PR TITLE
get_latest_updated_ts now returns None when record from neo4j is None

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -1,7 +1,7 @@
 import logging
 import textwrap
 from random import randint
-from typing import Dict, Any, no_type_check, List, Tuple, Union  # noqa: F401
+from typing import Dict, Any, no_type_check, List, Tuple, Union, Optional  # noqa: F401
 
 import time
 from beaker.cache import CacheManager
@@ -607,7 +607,7 @@ class Neo4jProxy(BaseProxy):
         return results
 
     @timer_with_counter
-    def get_latest_updated_ts(self) -> int:
+    def get_latest_updated_ts(self) -> Optional[int]:
         """
         API method to fetch last updated / index timestamp for neo4j, es
 
@@ -620,7 +620,10 @@ class Neo4jProxy(BaseProxy):
                                             param_dict={})
         # None means we don't have record for neo4j, es last updated / index ts
         record = record.single()
-        return record.get('ts', {}).get('latest_timestmap', 0)
+        if record:
+            return record.get('ts', {}).get('latest_timestmap', 0)
+        else:
+            return None
 
     @timer_with_counter
     @_CACHE.cache('_get_popular_tables_uris', _GET_POPULAR_TABLE_CACHE_EXPIRY_SEC)

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -446,6 +446,11 @@ class TestNeo4jProxy(unittest.TestCase):
             neo4j_last_updated_ts = neo4j_proxy.get_latest_updated_ts()
             self.assertEqual(neo4j_last_updated_ts, 0)
 
+            mock_execute.return_value.single.return_value = None
+            neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
+            neo4j_last_updated_ts = neo4j_proxy.get_latest_updated_ts()
+            self.assertIsNone(neo4j_last_updated_ts)
+
     def test_get_popular_tables(self) -> None:
         # Test cache hit
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:


### PR DESCRIPTION
Make sure you have checked **all** steps below.

### Title

- [x] My PR Title addresses the issue accurately and concisely. 
    - I hope so 😄 

### Description

- [x] Here are some details about my PR, including screenshots of any UI changes:
    - when `amundsen_updated_timestamp` does not exist in neo4j, the `record` returned can be None. Under these circumstances, `record` cannot respond to a `get` call, resulting in an uncaught exception. This patch returns None instead, and changes the return type hint to Optional[int]
    - <img width="1259" alt="Before stacktrace screenshot" src="https://user-images.githubusercontent.com/1591459/57107915-8754ab00-6cee-11e9-86e0-a7acc30b2f3b.png">
    - <img width="1293" alt="After stacktrace screenshot" src="https://user-images.githubusercontent.com/1591459/57107945-99cee480-6cee-11e9-82a5-31f3b4c3c7b7.png">


### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
    - `tests/unit/proxy/test_neo4j_proxy.py` has been updated

### Commits

- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - N/A

### Code Quality & Coverage

- [x] Passes `make test` 