### PR TITLE
Use name instead of qualifiedName and add cluster

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -36,7 +36,7 @@ class Config:
 
     # Display name of Atlas Entities that we use for amundsen project.
     # Atlas uses qualifiedName as indexed attribute. but also supports 'name' attribute.
-    ATLAS_NAME_ATTRIBUTE = 'qualifiedName'
+    ATLAS_NAME_ATTRIBUTE = 'name'
 
 
 class LocalConfig(Config):


### PR DESCRIPTION
### Summary of Changes

Currently the qualifiedName is the `normal name`@`cluster name` which makes all the names like `column@cluster1`.

Also, we switched to searching the table with `search_dsl`. Which allows us to search on all the properties (cluster, database, table) instead of only table name.

### Tests

I modified the atlas testing to adopt the new `search_dsl` change, also I added some patching and used `name` instead of `qualifiedName`.

### Documentation

No need to change documentation, will work by default with Atlas docker compose. No required settings change.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
