### PR TITLE
In Atlas Proxy, use correct hive URL and display name

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -36,7 +36,7 @@ class Config:
 
     # Display name of Atlas Entities that we use for amundsen project.
     # Atlas uses qualifiedName as indexed attribute. but also supports 'name' attribute.
-    ATLAS_NAME_ATTRIBUTE = 'qualifiedName'
+    ATLAS_NAME_ATTRIBUTE = 'name'
 
 
 class LocalConfig(Config):

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -1,4 +1,7 @@
+import inspect
 import unittest
+from functools import wraps
+
 from atlasclient.exceptions import BadRequest
 from mock import patch, MagicMock
 
@@ -7,6 +10,33 @@ from metadata_service.entity.popular_table import PopularTable
 from metadata_service.entity.table_detail import (Table, User, Tag, Column)
 from metadata_service.entity.tag_detail import TagDetail
 from metadata_service.exception import NotFoundException
+
+
+def _mock_get_table_entity(f, entity=None):
+    @wraps(f)
+    def wrapper(self):
+        print("mocking _get_table_entity")
+        with patch.object(self.proxy, '_get_table_entity'):
+            mocked_entity = MagicMock()
+            mocked_entity.entity = entity or self.entity1
+            if mocked_entity.entity == self.entity1:
+                mocked_entity.referredEntities = {
+                    self.test_column['guid']: self.test_column
+                }
+            else:
+                mocked_entity.referredEntities = {}
+            self.proxy._get_table_entity = MagicMock(return_value=(mocked_entity, {
+                'entity': self.entity_type,
+                'cluster': self.cluster,
+                'db': self.db,
+                'name': self.name
+            }))
+            # return mocked_entity
+            nr_parameters = len(inspect.signature(f).parameters)
+            args = [self, mocked_entity][0:nr_parameters]
+            f(*args)
+
+    return wrapper
 
 
 class TestAtlasProxy(unittest.TestCase):
@@ -38,12 +68,12 @@ class TestAtlasProxy(unittest.TestCase):
             'guid': 'DOESNT_MATTER',
             'typeName': 'COLUMN',
             'attributes': {
-                'qualifiedName': 'column@name',
+                'name': 'column',
+                'qualifiedName': f"{self.db}.Table1.column@{self.cluster}",
                 'type': 'Managed',
                 'description': 'column description',
                 'position': 1
             }
-
         }
 
         self.db_entity = {
@@ -51,8 +81,8 @@ class TestAtlasProxy(unittest.TestCase):
             'updateTime': 234,
             'typeName': self.entity_type,
             'attributes': {
-                'qualifiedName': self.db,
-                'name': 'self.db',
+                'qualifiedName': self.db + "@" + self.cluster,
+                'name': self.db,
                 'description': 'Dummy DB Description',
                 'owner': 'dummy@email.com',
             }
@@ -63,7 +93,7 @@ class TestAtlasProxy(unittest.TestCase):
             'typeName': self.entity_type,
             'updateTime': 123,
             'attributes': {
-                'qualifiedName': 'Table1_Qualified',
+                'qualifiedName': f"{self.db}.Table1@{self.cluster}",
                 'name': 'Table1',
                 'description': 'Dummy Description',
                 'owner': 'dummy@email.com',
@@ -82,7 +112,7 @@ class TestAtlasProxy(unittest.TestCase):
             'updateTime': 234,
             'typeName': self.entity_type,
             'attributes': {
-                'qualifiedName': 'Table2_Qualified',
+                'qualifiedName': f"{self.db}.Table2@{self.cluster}",
                 'name': 'Table1',
                 'description': 'Dummy Description',
                 'owner': 'dummy@email.com',
@@ -100,23 +130,6 @@ class TestAtlasProxy(unittest.TestCase):
             ]
         }
 
-    def _mock_get_table_entity(self, entity=None):
-        mocked_entity = MagicMock()
-        mocked_entity.entity = entity or self.entity1
-        if mocked_entity.entity == self.entity1:
-            mocked_entity.referredEntities = {
-                self.test_column['guid']: self.test_column
-            }
-        else:
-            mocked_entity.referredEntities = {}
-        self.proxy._get_table_entity = MagicMock(return_value=(mocked_entity, {
-            'entity': self.entity_type,
-            'cluster': self.cluster,
-            'db': self.db,
-            'name': self.name
-        }))
-        return mocked_entity
-
     def test_extract_table_uri_info(self):
         table_info = self.proxy._extract_info_from_uri(table_uri=self.table_uri)
         self.assertDictEqual(table_info, {
@@ -125,21 +138,6 @@ class TestAtlasProxy(unittest.TestCase):
             'db': self.db,
             'name': self.name
         })
-
-    def test_get_ids_from_basic_search(self):
-        entity1 = MagicMock()
-        entity1.guid = self.entity1['guid']
-
-        entity2 = MagicMock()
-        entity2.guid = self.entity2['guid']
-
-        basic_search_response = MagicMock()
-        basic_search_response.entities = [entity1, entity2]
-
-        self.proxy._driver.search_basic = MagicMock(return_value=[basic_search_response])
-        response = self.proxy._get_ids_from_basic_search(params={})
-        expected = ['1', '2']
-        self.assertListEqual(response, expected)
 
     def test_get_rel_attributes_dict(self):
         entity1 = MagicMock()
@@ -155,36 +153,37 @@ class TestAtlasProxy(unittest.TestCase):
         rel_attr_collection.entities = [db_entity]
 
         self.proxy._driver.entity_bulk = MagicMock(return_value=[rel_attr_collection])
-        response = self.proxy._get_rel_attributes_dict(entities=[entity1, entity2],
-                                                       attribute='db')
+        response = self.proxy._get_rel_attributes_dict(entities=[entity1, entity2], attribute='db')
         expected = {
             self.db_entity['guid']: db_entity
         }
         self.assertDictEqual(response, expected)
 
     def test_get_table_entity(self):
-        unique_attr_response = MagicMock()
+        entity1 = MagicMock()
+        entity1.guid = self.entity1['guid']
+        entity_results = MagicMock()
+        entity_results.entity = entity1
+        self.proxy._driver.entity_unique_attribute = MagicMock(return_value=entity_results)
 
-        self.proxy._driver.entity_unique_attribute = MagicMock(
-            return_value=unique_attr_response)
         ent, table_info = self.proxy._get_table_entity(table_uri=self.table_uri)
+
         self.assertDictEqual(table_info, {
             'entity': self.entity_type,
             'cluster': self.cluster,
             'db': self.db,
             'name': self.name
         })
-        self.assertEqual(ent.__repr__(), unique_attr_response.__repr__())
 
+    @_mock_get_table_entity
     def test_get_table(self):
-        self._mock_get_table_entity()
         response = self.proxy.get_table(table_uri=self.table_uri)
 
         classif_name = self.classification_entity['classifications'][0]['typeName']
         ent_attrs = self.entity1['attributes']
 
         col_attrs = self.test_column['attributes']
-        exp_col = Column(name=col_attrs['qualifiedName'],
+        exp_col = Column(name=col_attrs['name'],
                          description='column description',
                          col_type='Managed',
                          sort_order=col_attrs['position'])
@@ -201,18 +200,20 @@ class TestAtlasProxy(unittest.TestCase):
 
     def test_get_table_not_found(self):
         with self.assertRaises(NotFoundException):
-            self.proxy._driver.entity_unique_attribute = MagicMock(side_effect=Exception('Boom!'))
-            self.proxy.get_table(table_uri=self.table_uri)
+            with patch.object(self.proxy._driver, 'entity_unique_attribute'):
+                self.proxy._driver.entity_unique_attribute = MagicMock(side_effect=Exception('Boom!'))
+                self.proxy.get_table(table_uri=self.table_uri)
 
     def test_get_table_missing_info(self):
         with self.assertRaises(BadRequest):
-            local_entity = self.entity1
-            local_entity.pop('attributes')
-            unique_attr_response = MagicMock()
-            unique_attr_response.entity = local_entity
-
-            self.proxy._driver.entity_unique_attribute = MagicMock(return_value=unique_attr_response)
-            self.proxy.get_table(table_uri=self.table_uri)
+            with patch.object(self.proxy._driver, 'entity_unique_attribute'):
+                local_entity = MagicMock()
+                local_entity.guid = '1'
+                local_entity.__getitem__.side_effect = KeyError('attributes')
+                entity_results = MagicMock()
+                entity_results.entity = local_entity
+                self.proxy._driver.entity_unique_attribute = MagicMock(return_value=entity_results)
+                self.proxy.get_table(table_uri=self.table_uri)
 
     def test_get_popular_tables(self):
         entity1 = MagicMock()
@@ -230,7 +231,8 @@ class TestAtlasProxy(unittest.TestCase):
 
         db_entity = MagicMock()
         db_entity.attributes = {
-            'qualifiedName': self.db,
+            'name': self.db,
+            'qualifiedName': self.db + '@' + self.cluster,
             'clusterName': self.cluster
         }
 
@@ -244,9 +246,9 @@ class TestAtlasProxy(unittest.TestCase):
 
         expected = [
             PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
-                         name=ent1_attrs['qualifiedName'], description=ent1_attrs['description']),
+                         name=ent1_attrs['name'], description=ent1_attrs['description']),
             PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
-                         name=ent2_attrs['qualifiedName'], description=ent1_attrs['description']),
+                         name=ent2_attrs['name'], description=ent1_attrs['description']),
         ]
 
         self.assertEqual(expected.__repr__(), response.__repr__())
@@ -277,9 +279,9 @@ class TestAtlasProxy(unittest.TestCase):
 
         expected = [
             PopularTable(database=self.entity_type, cluster='', schema='',
-                         name=ent1_attrs['qualifiedName'], description=ent1_attrs['description']),
+                         name=ent1_attrs['name'], description=ent1_attrs['description']),
             PopularTable(database=self.entity_type, cluster='', schema='',
-                         name=ent2_attrs['qualifiedName'], description=ent1_attrs['description']),
+                         name=ent2_attrs['name'], description=ent1_attrs['description']),
         ]
 
         self.assertEqual(expected.__repr__(), response.__repr__())
@@ -289,13 +291,13 @@ class TestAtlasProxy(unittest.TestCase):
             self.proxy._driver.search_basic.create = MagicMock(side_effect=BadRequest('Boom!'))
             self.proxy.get_popular_tables(num_entries=2)
 
+    @_mock_get_table_entity
     def test_get_table_description(self):
-        self._mock_get_table_entity()
         response = self.proxy.get_table_description(table_uri=self.table_uri)
         self.assertEqual(response, self.entity1['attributes']['description'])
 
+    @_mock_get_table_entity
     def test_put_table_description(self):
-        self._mock_get_table_entity()
         self.proxy.put_table_description(table_uri=self.table_uri,
                                          description="DOESNT_MATTER")
 
@@ -314,9 +316,9 @@ class TestAtlasProxy(unittest.TestCase):
         expected = [TagDetail(tag_name=name, tag_count=0)]
         self.assertEqual(response.__repr__(), expected.__repr__())
 
+    @_mock_get_table_entity
     def test_add_tag(self):
         tag = "TAG"
-        self._mock_get_table_entity()
 
         with patch.object(self.proxy._driver.entity_bulk_classification, 'create') as mock_execute:
             self.proxy.add_tag(table_uri=self.table_uri, tag=tag)
@@ -324,9 +326,9 @@ class TestAtlasProxy(unittest.TestCase):
                 data={'classification': {'typeName': tag}, 'entityGuids': [self.entity1['guid']]}
             )
 
+    @_mock_get_table_entity
     def test_delete_tag(self):
         tag = "TAG"
-        self._mock_get_table_entity()
         mocked_entity = MagicMock()
         self.proxy._driver.entity_guid = MagicMock(return_value=mocked_entity)
 
@@ -334,43 +336,46 @@ class TestAtlasProxy(unittest.TestCase):
             self.proxy.delete_tag(table_uri=self.table_uri, tag=tag)
             mock_execute.assert_called_with()
 
-    def test_add_owner(self):
+    @_mock_get_table_entity
+    def test_add_owner(self, entity):
         owner = "OWNER"
-        entity = self._mock_get_table_entity()
         with patch.object(entity, 'update') as mock_execute:
             self.proxy.add_owner(table_uri=self.table_uri, owner=owner)
             mock_execute.assert_called_with()
 
+    @_mock_get_table_entity
     def test_get_column(self):
-        self._mock_get_table_entity()
         response = self.proxy._get_column(
             table_uri=self.table_uri,
-            column_name=self.test_column['attributes']['qualifiedName'])
+            column_name=self.test_column['attributes']['name'])
         self.assertDictEqual(response, self.test_column)
 
+    @_mock_get_table_entity
     def test_get_column_wrong_name(self):
         with self.assertRaises(NotFoundException):
-            self._mock_get_table_entity()
             self.proxy._get_column(table_uri=self.table_uri, column_name='FAKE')
 
     def test_get_column_no_referred_entities(self):
         with self.assertRaises(NotFoundException):
             local_entity = self.entity2
             local_entity['attributes']['columns'] = [{'guid': 'ent_2_col'}]
-            self._mock_get_table_entity(local_entity)
-            self.proxy._get_column(table_uri=self.table_uri, column_name='FAKE')
 
+            @_mock_get_table_entity
+            def test(s):
+                s.proxy._get_column(table_uri=s.table_uri, column_name='FAKE')
+            test(self)
+
+    @_mock_get_table_entity
     def test_get_column_description(self):
-        self._mock_get_table_entity()
         response = self.proxy.get_column_description(
             table_uri=self.table_uri,
-            column_name=self.test_column['attributes']['qualifiedName'])
+            column_name=self.test_column['attributes']['name'])
         self.assertEqual(response, self.test_column['attributes'].get('description'))
 
+    @_mock_get_table_entity
     def test_put_column_description(self):
-        self._mock_get_table_entity()
         self.proxy.put_column_description(table_uri=self.table_uri,
-                                          column_name=self.test_column['attributes']['qualifiedName'],
+                                          column_name=self.test_column['attributes']['name'],
                                           description='DOESNT_MATTER')
 
 


### PR DESCRIPTION
### Summary of Changes

* Construct qualifiedName from URL

* Use Atlas qualifiedName structure: `database.table@cluster`

* In frontend show table name instead of `qualifiedName`

### Tests

* Correct qualifiedName in test tables

* Use name instead of qualifiedName for Table and Column types

* Add mocking decorator that patches instead of overwriting Atlas Client

### Documentation

Works by default with Atlas, user does not need to change anything.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
