### PR TITLE
Use PopularTable model when return user resource

### DIFF
--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -3,7 +3,7 @@ from typing import Iterable, Mapping, Union
 
 from flask_restful import Resource, fields, marshal
 
-from metadata_service.api.table import table_detail_fields
+from metadata_service.api.popular_tables import popular_table_fields
 from metadata_service.exception import NotFoundException
 from metadata_service.proxy import get_proxy_client
 from metadata_service.util import UserResourceRel
@@ -23,7 +23,7 @@ user_detail_fields = {
 }
 
 table_list_fields = {
-    'table': fields.List(fields.Nested(table_detail_fields))
+    'table': fields.List(fields.Nested(popular_table_fields))
 }
 
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -771,8 +771,13 @@ class Neo4jProxy(BaseProxy):
         table_records = record.single().get('table_records', [])
 
         for record in table_records:
-            # todo: decide whether we want to return a list of table entities or just table_uri
-            results.append(self.get_table(table_uri=record['key']))
+            _, last_neo4j_record = self._exec_col_query(record['key'])
+            results.append(PopularTable(
+                database=last_neo4j_record['db']['name'],
+                cluster=last_neo4j_record['clstr']['name'],
+                schema=last_neo4j_record['schema']['name'],
+                name=last_neo4j_record['tbl']['name'],
+                description=self._safe_get(last_neo4j_record, 'tbl_dscrpt', 'description')))
         return {'table': results}
 
     @timer_with_counter

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 
 setup(


### PR DESCRIPTION
### Summary of Changes

When building Amundsen people, we found that it is not necessary to use Table model when return table object to FE. The table model contains all the metadata related table detail page which the payload size is huge. Switch to use popularTable model.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
