### PR TITLE
Fix setup.py GitHub url

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ __version__ = '1.0.6'
 setup(
     name='amundsen-metadata',
     version=__version__,
-    description='Metadata service package for Amundsen',
-    url='https://www.github.com/lyft/amundsen',
+    description='Metadata service for Amundsen',
+    url='https://www.github.com/lyft/amundsenmetadatalibrary',
     maintainer='Lyft',
     maintainer_email='dev@lyft.com',
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
Also tweaked description to be similar to search service

Currently if you go to pypi and click the homepage link you’ll get a 404


