### PR TITLE
Fix neo4j_proxy get_user_detail api method and bump up version

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -699,16 +699,18 @@ class Neo4jProxy(BaseProxy):
 
         query = textwrap.dedent("""
         MATCH (user:User {key: $user_id})
-        OPTIONAL MATCH (user)-[:manage_by]->(manager:User)
+        OPTIONAL MATCH (user)-[:MANAGE_BY]->(manager:User)
         RETURN user as user_record, manager as manager_record
         """)
 
         record = self._execute_cypher_query(statement=query,
                                             param_dict={'user_id': user_id})
-        if not record:
+        single_result = record.single()
+
+        if not single_result:
             raise NotFoundException('User {user_id} '
                                     'not found in the graph'.format(user_id=user_id))
-        single_result = record.single()
+
         record = single_result.get('user_record', {})
         manager_record = single_result.get('manager_record', {})
         if manager_record:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 
 setup(

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -11,6 +11,7 @@ from metadata_service.entity.popular_table import PopularTable
 from metadata_service.entity.table_detail import (Application, Column, Table, Tag,
                                                   Watermark, Source, Statistics, User)
 from metadata_service.entity.tag_detail import TagDetail
+from metadata_service.exception import NotFoundException
 from metadata_service.proxy.neo4j_proxy import Neo4jProxy
 from metadata_service.util import UserResourceRel
 
@@ -579,6 +580,12 @@ class TestNeo4jProxy(unittest.TestCase):
                                                       relation_type=UserResourceRel.follow)
             self.assertEquals(mock_run.call_count, 1)
             self.assertEquals(mock_commit.call_count, 1)
+
+    def test_get_invalid_user(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            mock_execute.return_value.single.return_value = None
+            neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
+            self.assertRaises(NotFoundException, neo4j_proxy.get_user_detail, user_id='invalid_email')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

1. Relationship of `manage_by` should be in upper case
2. BoltStatementResult is not None even user_id is invalid. We should check whether `single_result`
 is None instead
3. Bump up amundsenmetadatalibrary version

### Tests

_What tests did you add or modify and why? 
1. Added test to ensure NotFoundException is raised in get_user_detail function if input user email is invalid.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [X] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [X] PR includes a summary of changes. 
- [X] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [X] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [X] PR passes `make test`
- [X] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
