### PR TITLE
For Atlas proxy, use entity ID (guid) instead of table uri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,21 @@ script:
 after_success:
 - codecov
 deploy:
-  provider: pypi
+- provider: pypi
   user: amundsen-dev
   password:
     secure: zIFmsUEvMgxG/gxmswAno4Y8MnfSAMGYGTAw4V4iAVthKqkLZHuyARDtl/zSpbiSlcfd8UcWvrvQ8WJDDd09iXRB/QGxz2CmVxBpUh9NT5NOWmgFg2cc7GUc7CyTP94QrSZWOFVGlGt9PHCZsvXh2gTTTUTEvQ3t9G56isCyMrfYbS+csCx3ffFeW+Wu/bTHK/azMLPldho/EOjgGrUUOC1nW5l9K92IXg0T/pYg6aDXlJ7l+ds+9R/Gehh/lz/j46pHimUdDTGa39EO52/VMQwzDbENmM8S6W0lQpXUAxx80s45mnmE2TihTzKOjB0aZJ20arxnPwcBrWZC78M7+nBjlPftDIY4kvFFP6Mim3XNTQLnvwtSMA3erjoawyb8QIQA+SgeNRKvRcJrBBVOuQsKeY4ScNxO3XQlhAP6nF7ATuUFAY8lsLAgVGwo5VBvGodzuY9mm3NtX9RT4fh2LMBlE20sgcwvi6lFPsoI0061UwhAjThQbx25txXGcn3rTIX+N2WCJpcuw0vMOSCZApUhC6B56bThlpwe9+mHboMrws+kAJLyefymaj4jbKq+ex+nFIP6HQ1LfXmsIVPnR5571pIqfWkqxJfW+Lmrh39QeEIEG1o7pNvMv05wP9/Jo98S4QOQk8iO+omHuBIsaNRS/84ZmkWktnt8AuQw6NE=
   distributions: sdist bdist_wheel
+  skip_existing: true
   on:
     tags: true
     repo: lyft/amundsenmetadatalibrary
-after_success:
-  - codecov
+- provider: script
+  script: docker login -u amundsendev -p $DOCKER_LOGIN_PASSWORD && make build-push-image
+  on:
+    branch: master
+    tags: true
+    repo: lyft/amundsenmetadatalibrary
+env:
+  global:
+    secure: qK+qtPjx419eBBhqH2mRPHTkEVgKirw4kC5uil2Z/uuXElTdQMqMbrjGb7SmeYOI41bmq5j6rOgZs6EBVHrIlJXFVITAcr3mbBpOanaMVSdQf6cCcUZ622idKNk1kdlcSeoYyBmLs2PWa43XK8mX6bgcjbivRI6S79FLdK3NffEt17ERDnlL5Ud8QIUnYepw4oB5pKUjCGiz0T9VlKpEPiB51UUBRNfLmQnhLjwQJ29H3GBoI4YAC4B5w2az0YGADg3xqmMs2agsV+mMbHR0NqSoZdyX4t69ffrEjOtimlZ6TgRR7hHmTCUNx1MLRlx2B/M07Dl9T2fD2LINzlwXC24YtubaoQBSj+ufyYdqLr14SV99NiaG18uGGXbth+fucO7CK5V0J4eXnBB/9ZaMmVBH6Zp0bVJwSl+ppf8yklqRsC9J6og7gAMaIAgH9OyeYgZzuTRJXzbJpSCOSx7GcX2zwlpyvqoi5/hIv6R8dz0CE/lqxgnQz4LqH9dwgiPFB9ogIs++TJcSy81QMyvJDWvS5mzQLRNAZCXt70HQiZmuj9XQnE3RBIQw15yznwWYmiczRsJj7VKgQ4Ul/BfgY6igDyPSTJDFOBf6qnoC3jRgqf/Ecg0C6paehC4YoyBHyd9aywKxrtnWPytQGcs9BbU1IuZyshwinhSxbaw3v4c=

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+IMAGE := amundsendev/amundsen-metadata
+VERSION:= $(shell grep -m 1 '__version__' setup.py | cut -d '=' -f 2 | tr -d "'" | tr -d '[:space:]')
+
 .PHONY: clean
 clean:
 	find . -name \*.pyc -delete
@@ -17,3 +20,17 @@ mypy:
 
 .PHONY: test
 test: test_unit lint mypy
+
+.PHONY: image
+image:
+	docker build -f public.Dockerfile -t ${IMAGE}:${VERSION} .
+	docker tag ${IMAGE}:${VERSION} ${IMAGE}:latest
+
+.PHONY: push-image
+push-image:
+	docker push ${IMAGE}:${VERSION}
+	docker push ${IMAGE}:latest
+
+.PHONY: build-push-image
+build-push-image: image push-image
+

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -3,7 +3,7 @@ from typing import Iterable, Mapping, Union
 
 from flask_restful import Resource, fields, marshal
 
-from metadata_service.api.table import table_detail_fields
+from metadata_service.api.popular_tables import popular_table_fields
 from metadata_service.exception import NotFoundException
 from metadata_service.proxy import get_proxy_client
 from metadata_service.util import UserResourceRel
@@ -23,7 +23,7 @@ user_detail_fields = {
 }
 
 table_list_fields = {
-    'table': fields.List(fields.Nested(table_detail_fields))
+    'table': fields.List(fields.Nested(popular_table_fields))
 }
 
 

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -771,8 +771,13 @@ class Neo4jProxy(BaseProxy):
         table_records = record.single().get('table_records', [])
 
         for record in table_records:
-            # todo: decide whether we want to return a list of table entities or just table_uri
-            results.append(self.get_table(table_uri=record['key']))
+            _, last_neo4j_record = self._exec_col_query(record['key'])
+            results.append(PopularTable(
+                database=last_neo4j_record['db']['name'],
+                cluster=last_neo4j_record['clstr']['name'],
+                schema=last_neo4j_record['schema']['name'],
+                name=last_neo4j_record['tbl']['name'],
+                description=self._safe_get(last_neo4j_record, 'tbl_dscrpt', 'description')))
         return {'table': results}
 
     @timer_with_counter

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.6'
+__version__ = '1.0.7'
 
 
 setup(


### PR DESCRIPTION
### Summary of Changes

* Use entity id instead of table uri. In Atlas part, use the guid for table_id and column_id.

### Tests

* Update test_atlas_proxy to test using of entity id.

### Documentation

* Works by default with Atlas.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
- [ ] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
