### PR TITLE
remove on match statement in add owner method

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -432,17 +432,16 @@ class Neo4jProxy(BaseProxy):
                   owner: str) -> None:
         """
         Update table owner informations.
-        1. Do a upsert of the owner(user) node.
+        1. Do a create if not exists query of the owner(user) node.
         2. Do a upsert of the owner/owned_by relation.
 
         :param table_uri:
         :param owner:
         :return:
         """
-        upsert_owner_query = textwrap.dedent("""
+        create_owner_query = textwrap.dedent("""
         MERGE (u:User {key: $user_email})
         on CREATE SET u={email: $user_email, key: $user_email}
-        on MATCH SET u={email: $user_email, key: $user_email}
         """)
 
         upsert_owner_relation_query = textwrap.dedent("""
@@ -454,7 +453,7 @@ class Neo4jProxy(BaseProxy):
         try:
             tx = self._driver.session().begin_transaction()
             # upsert the node
-            tx.run(upsert_owner_query, {'user_email': owner})
+            tx.run(create_owner_query, {'user_email': owner})
             result = tx.run(upsert_owner_relation_query, {'user_email': owner,
                                                           'tbl_key': table_uri})
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.8'
+__version__ = '1.0.9'
 
 
 setup(


### PR DESCRIPTION
### Summary of Changes

Remove `on MATCH` statement in add_owner method, because it will update existing record with only `email` and `key` field and remove all other attributes.

### Tests

_What tests did you add or modify and why? If no tests were added or modified, explain why. Remove this line_

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
