### PR TITLE
Improve performance of getting bookmarked tables, refactored getting freq read table query

### DIFF
--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -121,7 +121,7 @@ class UserFollowAPI(Resource):
             LOGGER.exception('UserFollowAPI DELETE Failed')
             return {'message': 'The user {} for table_uri {} '
                                'is not deleted successfully'.format(user_id,
-                                                                  table_uri)}, \
+                                                                    table_uri)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
 

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -75,7 +75,7 @@ class UserFollowAPI(Resource):
             return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
 
         except Exception:
-            LOGGER.exception('UserFollowAPI Failed')
+            LOGGER.exception('UserFollowAPI GET Failed')
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
@@ -95,6 +95,7 @@ class UserFollowAPI(Resource):
                                'is added successfully'.format(user_id,
                                                               table_uri)}, HTTPStatus.OK
         except Exception as e:
+            LOGGER.exception('UserFollowAPI PUT Failed')
             return {'message': 'The user {} for table_uri {} '
                                'is not added successfully'.format(user_id,
                                                                   table_uri)}, \
@@ -117,8 +118,9 @@ class UserFollowAPI(Resource):
                                'is added successfully'.format(user_id,
                                                               table_uri)}, HTTPStatus.OK
         except Exception as e:
+            LOGGER.exception('UserFollowAPI DELETE Failed')
             return {'message': 'The user {} for table_uri {} '
-                               'is not added successfully'.format(user_id,
+                               'is not deleted successfully'.format(user_id,
                                                                   table_uri)}, \
                 HTTPStatus.INTERNAL_SERVER_ERROR
 
@@ -149,6 +151,7 @@ class UserOwnAPI(Resource):
             return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
 
         except Exception:
+            LOGGER.exception('UserOwnAPI GET Failed')
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
@@ -166,6 +169,7 @@ class UserOwnAPI(Resource):
                                'is added successfully'.format(user_id,
                                                               table_uri)}, HTTPStatus.OK
         except Exception as e:
+            LOGGER.exception('UserOwnAPI PUT Failed')
             return {'message': 'The owner {} for table_uri {} '
                                'is not added successfully'.format(user_id,
                                                                   table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
@@ -177,6 +181,7 @@ class UserOwnAPI(Resource):
                                'is deleted successfully'.format(user_id,
                                                                 table_uri)}, HTTPStatus.OK
         except Exception:
+            LOGGER.exception('UserOwnAPI DELETE Failed')
             return {'message': 'The owner {} for table_uri {} '
                                'is not deleted successfully'.format(user_id,
                                                                     table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
@@ -199,12 +204,12 @@ class UserReadAPI(Resource):
         :return:
         """
         try:
-            resources = self.client.get_table_by_user_relation(user_email=user_id,
-                                                               relation_type=UserResourceRel.read)
+            resources = self.client.get_frequently_used_tables(user_email=user_id)
             return marshal(resources, table_list_fields), HTTPStatus.OK
 
         except NotFoundException:
             return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
 
         except Exception:
+            LOGGER.exception('UserReadAPI GET Failed')
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -8,6 +8,8 @@ from metadata_service.exception import NotFoundException
 from metadata_service.proxy import get_proxy_client
 from metadata_service.util import UserResourceRel
 
+import logging
+
 
 user_detail_fields = {
     'email': fields.String,
@@ -27,12 +29,16 @@ table_list_fields = {
 }
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 class UserDetailAPI(Resource):
     """
     User detail API for people resources
     """
 
     def __init__(self) -> None:
+
         self.client = get_proxy_client()
 
     def get(self, user_id: str) -> Iterable[Union[Mapping, int, None]]:
@@ -69,6 +75,7 @@ class UserFollowAPI(Resource):
             return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
 
         except Exception:
+            LOGGER.exception('UserFollowAPI Failed')
             return {'message': 'Internal server error!'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -407,6 +407,9 @@ class AtlasProxy(BaseProxy):
                                    relation_type: UserResourceRel) -> Dict[str, Any]:
         pass
 
+    def get_frequently_used_tables(self, *, user_email: str) -> Dict[str, Any]:
+        pass
+
     def add_table_relation_by_user(self, *,
                                    table_uri: str,
                                    user_email: str,

--- a/metadata_service/proxy/base_proxy.py
+++ b/metadata_service/proxy/base_proxy.py
@@ -80,6 +80,10 @@ class BaseProxy(metaclass=ABCMeta):
         pass
 
     @abstractmethod
+    def get_frequently_used_tables(self, *, user_email: str) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
     def add_table_relation_by_user(self, *,
                                    table_uri: str,
                                    user_email: str,

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -21,7 +21,6 @@ from metadata_service.util import UserResourceRel
 
 _CACHE = CacheManager(**parse_cache_config_options({'cache.type': 'memory'}))
 
-
 # Expire cache every 11 hours + jitter
 _GET_POPULAR_TABLE_CACHE_EXPIRY_SEC = 11 * 60 * 60 + randint(0, 3600)
 
@@ -36,10 +35,10 @@ class Neo4jProxy(BaseProxy):
     def __init__(self, *,
                  host: str,
                  port: int,
-                 user: str ='neo4j',
-                 password: str ='',
-                 num_conns: int =50,
-                 max_connection_lifetime_sec: int =100) -> None:
+                 user: str = 'neo4j',
+                 password: str = '',
+                 num_conns: int = 50,
+                 max_connection_lifetime_sec: int = 100) -> None:
         """
         There's currently no request timeout from client side where server
         side can be enforced via "dbms.transaction.timeout"
@@ -652,7 +651,7 @@ class Neo4jProxy(BaseProxy):
         return [record['table_key'] for record in records]
 
     @timer_with_counter
-    def get_popular_tables(self, *, num_entries: int =10) -> List[PopularTable]:
+    def get_popular_tables(self, *, num_entries: int = 10) -> List[PopularTable]:
         """
         Retrieve popular tables. As popular table computation requires full scan of table and user relationship,
         it will utilize cached method _get_popular_tables_uris.
@@ -752,33 +751,28 @@ class Neo4jProxy(BaseProxy):
         :return:
         """
         relation, _ = self._get_relation_by_type(relation_type)
-        # relationship can't be parameterized
-        query_key = 'key: "{user_id}"'.format(user_id=user_email)
 
         query = textwrap.dedent("""
-        MATCH (user:User {{{key}}})-[:{relation}]->(tbl:Table)
-        RETURN COLLECT(DISTINCT tbl) as table_records
-        """).format(key=query_key,
-                    relation=relation)
+MATCH (user:User {{key: $query_key}})-[:{relation}]->(tbl:Table)-[:TABLE_OF]->
+(schema:Schema)-[:SCHEMA_OF]->(clstr:Cluster)-[:CLUSTER_OF]->(db:Database)
+WITH db, clstr, schema, tbl
+OPTIONAL MATCH (tbl)-[:DESCRIPTION]->(tbl_dscrpt:Description)
+RETURN db, clstr, schema, tbl, tbl_dscrpt""").format(relation=relation)
 
-        record = self._execute_cypher_query(statement=query,
-                                            param_dict={})
+        table_records = self._execute_cypher_query(statement=query, param_dict={'query_key': user_email})
 
-        if not record:
-            raise NotFoundException('User {user_id} does not {relation} '
-                                    'any resources'.format(user_id=user_email,
-                                                           relation=relation))
+        if not table_records:
+            raise NotFoundException('User {user_id} does not {relation} any resources'.format(user_id=user_email,
+                                                                                              relation=relation))
         results = []
-        table_records = record.single().get('table_records', [])
 
         for record in table_records:
-            _, last_neo4j_record = self._exec_col_query(record['key'])
             results.append(PopularTable(
-                database=last_neo4j_record['db']['name'],
-                cluster=last_neo4j_record['clstr']['name'],
-                schema=last_neo4j_record['schema']['name'],
-                name=last_neo4j_record['tbl']['name'],
-                description=self._safe_get(last_neo4j_record, 'tbl_dscrpt', 'description')))
+                database=record['db']['name'],
+                cluster=record['clstr']['name'],
+                schema=record['schema']['name'],
+                name=record['tbl']['name'],
+                description=self._safe_get(record, 'tbl_dscrpt', 'description')))
         return {'table': results}
 
     @timer_with_counter

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.11'
+__version__ = '1.0.12'
 
 
 setup(

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -504,33 +504,39 @@ class TestNeo4jProxy(unittest.TestCase):
             self.assertEquals(neo4j_user.email, 'test_email')
 
     def test_get_resources_by_user_relation(self) -> None:
-        with patch.object(GraphDatabase, 'driver'), \
-            patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute, \
-                patch.object(Neo4jProxy, '_exec_col_query') as mock_col_query:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
 
-            mock_execute.return_value.single.return_value = {
-                'table_records': [
-                    {
-                        'key': 'table_uri',
-
-                    }
-                ]
-            }
-
-            mock_col_query.return_value = 'not_related', {
-                'db': {
-                    'name': 'db_name'
-                },
-                'clstr': {
-                    'name': 'cluster'
-                },
-                'schema': {
-                    'name': 'schema'
-                },
-                'tbl': {
-                    'name': 'table_name'
+            mock_execute.return_value = [
+                {
+                    'tbl': {
+                        'name': 'table_name'
+                    },
+                    'db': {
+                        'name': 'db_name'
+                    },
+                    'clstr': {
+                        'name': 'cluster'
+                    },
+                    'schema': {
+                        'name': 'schema'
+                    },
                 }
-            }
+            ]
+
+            # mock_col_query.return_value = 'not_related', {
+            #     'db': {
+            #         'name': 'db_name'
+            #     },
+            #     'clstr': {
+            #         'name': 'cluster'
+            #     },
+            #     'schema': {
+            #         'name': 'schema'
+            #     },
+            #     'tbl': {
+            #         'name': 'table_name'
+            #     }
+            # }
 
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
             result = neo4j_proxy.get_table_by_user_relation(user_email='test_user',

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -523,21 +523,6 @@ class TestNeo4jProxy(unittest.TestCase):
                 }
             ]
 
-            # mock_col_query.return_value = 'not_related', {
-            #     'db': {
-            #         'name': 'db_name'
-            #     },
-            #     'clstr': {
-            #         'name': 'cluster'
-            #     },
-            #     'schema': {
-            #         'name': 'schema'
-            #     },
-            #     'tbl': {
-            #         'name': 'table_name'
-            #     }
-            # }
-
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
             result = neo4j_proxy.get_table_by_user_relation(user_email='test_user',
                                                             relation_type=UserResourceRel.follow)


### PR DESCRIPTION
### Summary of Changes

Previously, Metadata service was performing queries against each columns unnecessarily while getting bookmarked table. This change is to remove those query against columns.

Additionally, refactored query that retrieves frequently used table to fetch the one with `published_tag` and to get latest read data up to 50 tables.

### Tests

Unit tested. Integration tested locally.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
