### PR TITLE
Updated Dockerfile to be flexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ $ docker run -p 5000:5000 amundsendev/amundsen-metadata
 $ curl -v http://localhost:5000/healthcheck
 ```
 
+## Instructions to start the service with gunicorn (production use case)
+Note that there below command uses default config of gunicorn. Please visit [Gunicorn homepage](https://gunicorn.org/ "Gunicorn") for more information.
+```bash
+$ docker pull amundsendev/amundsen-metadata:latest
+$ docker run -p 5000:5000 amundsendev/amundsen-metadata gunicorn --bind 0.0.0.0:5000 metadata_service.metadata_wsgi
+
+-- In different terminal, verify getting HTTP/1.0 200 OK
+$ curl -v http://localhost:5000/healthcheck
+```
+
 ## Production environment
 By default, Flask comes with Werkzeug webserver, which is for development. For production environment use production grade web server such as [Gunicorn](https://gunicorn.org/ "Gunicorn").
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $ docker run -p 5000:5000 amundsendev/amundsen-metadata
 $ curl -v http://localhost:5000/healthcheck
 ```
 
-## Instructions to start the service with gunicorn (production use case)
+## Instructions to start the service from Docker image with gunicorn (production use case)
 Note that there below command uses default config of gunicorn. Please visit [Gunicorn homepage](https://gunicorn.org/ "Gunicorn") for more information.
 ```bash
 $ docker pull amundsendev/amundsen-metadata:latest

--- a/public.Dockerfile
+++ b/public.Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY . /app
 RUN pip3 install -r requirements.txt
 RUN python3 setup.py install
+RUN pip3 install gunicorn
 
-ENTRYPOINT [ "python3" ]
-CMD [ "metadata_service/metadata_wsgi.py" ]
+CMD [ "python3", "metadata_service/metadata_wsgi.py" ]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = '1.0.15'
+__version__ = '1.0.16'
 
 
 setup(


### PR DESCRIPTION
### Summary of Changes

Have all execution command into CMD so that execution of Docker is flexible enough to support other WSGI web-server such as gunicorn.

Example:
`docker run -p 5000:5000 amundsendev/amundsen-metadata gunicorn --bind 0.0.0.0:5000 metadata_service.metadata_wsgi`

### Tests
Tested in local

### Documentation

Updated README.md

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
- [x] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
