### PR TITLE
Added cache for atlas proxy popular table API.

### DIFF
--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -146,7 +146,17 @@ class TestAtlasProxy(unittest.TestCase, Data):
         metadata_collection.entities_with_relationships = MagicMock(return_value=[metadata1, metadata2])
 
         self.proxy._driver.entity_bulk = MagicMock(return_value=[metadata_collection])
+
         response = self.proxy.get_popular_tables(num_entries=2)
+
+        # Call multiple times for cache test.
+        self.proxy.get_popular_tables(num_entries=2)
+        self.proxy.get_popular_tables(num_entries=2)
+        self.proxy.get_popular_tables(num_entries=2)
+        self.proxy.get_popular_tables(num_entries=2)
+
+        self.assertEqual(self.proxy._driver.entity_bulk.call_count, 1)
+
         ent1_attrs = self.entity1['attributes']
         ent2_attrs = self.entity2['attributes']
 
@@ -175,7 +185,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
         metadata_collection = MagicMock()
         metadata_collection.entities_with_relationships = MagicMock(return_value=[metadata1, metadata2])
 
-        self.proxy._driver.entity_bulk = MagicMock(return_value=[metadata_collection])
+        self.proxy._get_metadata_collection = MagicMock(return_value=[metadata_collection])
         response = self.proxy.get_popular_tables(num_entries=2)
         ent1_attrs = self.entity1['attributes']
         ent2_attrs = self.entity2['attributes']
@@ -191,8 +201,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
     def test_get_popular_tables_search_exception(self):
         with self.assertRaises(NotFoundException):
-            self.proxy._get_flat_values_from_dsl = MagicMock(return_value=[])
-            self.proxy._driver.entity_bulk = MagicMock(return_value=None)
+            self.proxy._get_metadata_collection = MagicMock(return_value=None)
 
             self.proxy.get_popular_tables(num_entries=2)
 

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -1,5 +1,6 @@
 import copy
 import unittest
+
 from atlasclient.exceptions import BadRequest
 from mock import patch, MagicMock
 
@@ -185,15 +186,15 @@ class TestAtlasProxy(unittest.TestCase, Data):
         metadata_collection = MagicMock()
         metadata_collection.entities_with_relationships = MagicMock(return_value=[metadata1, metadata2])
 
-        self.proxy._get_metadata_collection = MagicMock(return_value=[metadata_collection])
+        self.proxy._driver.entity_bulk = MagicMock(return_value=[metadata_collection])
         response = self.proxy.get_popular_tables(num_entries=2)
         ent1_attrs = self.entity1['attributes']
         ent2_attrs = self.entity2['attributes']
 
         expected = [
-            PopularTable(database=self.entity_type, cluster='default', schema='default',
+            PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
                          name=ent1_attrs['name'], description=ent1_attrs['description']),
-            PopularTable(database=self.entity_type, cluster='default', schema='default',
+            PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
                          name=ent2_attrs['name'], description=ent1_attrs['description']),
         ]
 
@@ -201,9 +202,9 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
     def test_get_popular_tables_search_exception(self):
         with self.assertRaises(NotFoundException):
-            self.proxy._get_metadata_collection = MagicMock(return_value=None)
-
-            self.proxy.get_popular_tables(num_entries=2)
+            self.proxy._get_flat_values_from_dsl = MagicMock(return_value=None)
+            self.proxy._driver.entity_bulk = MagicMock(return_value=None)
+            self.proxy._get_metadata_entities({'query': 'test'})
 
     def test_get_table_description(self):
         self._mock_get_table_entity()


### PR DESCRIPTION

### Summary of Changes

* This PR includes caching of popular tables API for atlas proxy.
* Implementation is similar to neo4j's and uses beaker.
* Added _get_metadata_collection function which isolates the two atlas calls for fetching metadata id and metadata collection.

### Tests

* Changed test cases in `test_atlas_proxy.py`


### Documentation

Nothing was added or removed.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ *] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [*] PR includes a summary of changes. 
- [*] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [*] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [*] PR passes `make test`
- [*] I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
