### PR TITLE
Bugfix for tags API

### DIFF
--- a/tests/unit/api/table/test_table_tag_api.py
+++ b/tests/unit/api/table/test_table_tag_api.py
@@ -1,0 +1,61 @@
+from http import HTTPStatus
+
+from mock import patch, Mock
+
+from metadata_service.exception import NotFoundException
+
+from tests.unit.test_basics import BasicTestCase
+
+TABLE_URI = 'wizards'
+TAG = 'underage_wizards'
+
+
+class TestTableTagAPI(BasicTestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.mock_client = patch('metadata_service.api.table.get_proxy_client')
+        self.mock_proxy = self.mock_client.start().return_value = Mock()
+
+    def tearDown(self):
+        super().tearDown()
+        self.mock_client.stop()
+
+    def test_should_update_tag(self) -> None:
+        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}')
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.mock_proxy.add_tag.assert_called_with(table_uri=TABLE_URI, tag=TAG)
+
+    def test_should_fail_to_update_tag_when_table_not_found(self) -> None:
+        self.mock_proxy.add_tag.side_effect = NotFoundException(message='cannot find table')
+
+        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag/{TAG}')
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_should_delete_tag(self) -> None:
+        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}')
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.mock_proxy.delete_tag.assert_called_with(table_uri=TABLE_URI, tag=TAG)
+
+    def test_should_fail_to_delete_tag_when_table_not_found(self) -> None:
+        self.mock_proxy.delete_tag.side_effect = NotFoundException(message='cannot find table')
+
+        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag/{TAG}')
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+    def test_should_update_tag_from_body_params(self) -> None:
+        response = self.app.test_client().put(f'/table/{TABLE_URI}/tag', json={"tag": TAG})
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.mock_proxy.add_tag.assert_called_with(table_uri=TABLE_URI, tag=TAG)
+        
+    def test_should_delete_tag_from_body_params(self) -> None:
+        response = self.app.test_client().delete(f'/table/{TABLE_URI}/tag', json={"tag": TAG})
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.mock_proxy.delete_tag.assert_called_with(table_uri=TABLE_URI, tag=TAG)
+


### PR DESCRIPTION
### Summary of Changes
This bug is not super critical but worth fixing. There are currently two paths for the TableTagAPI `/table/<path:table_uri>/tag` and `/table/<path:table_uri>/tag/<tag>`. The path `/table/<path:table_uri>/tag/<tag>` works and the path `/table/<path:table_uri>/tag` always fails. 

These results can be seen in the units tests in this PR. The failures is as follows: 
```
2019-10-09T22:09:51-0400.355 [INFO] __init__.create_app:63 (38365:MainThread) - Created app with config name metadata_service.config.LocalConfig
2019-10-09T22:09:51-0400.356 [INFO] __init__.create_app:64 (38365:MainThread) - Using backend metadata_service.proxy.neo4j_proxy.Neo4jProxy
2019-10-09T22:09:51-0400.389 [ERROR] app.log_exception:1761 (38365:MainThread) - Exception on /table/wizards/tag [PUT]
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/flask_restful/__init__.py", line 480, in wrapper
    resp = resource(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/flask/views.py", line 88, in view
    return self.dispatch_request(*args, **kwargs)
  File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/flask_restful/__init__.py", line 595, in dispatch_request
    resp = meth(*args, **kwargs)
TypeError: put() missing 1 required positional argument: 'tag'
```

Possible solutions to bug:
1. Delete the second path. Do we need two paths for the same TableTagAPI? 
2. Fix the TableTagAPIs to allow both paths to work. 

I'm personally in favor of options (1) but I want to make sure I do what's best for the app! I'm happy to implement either solution. 

### Tests
Unit tests

### Documentation
None

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [ ] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [ ] PR includes a summary of changes. 
- [ ] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [ ] PR passes `make test`
