### PR TITLE
Add basic setup for using a gremlin proxy

### DIFF
--- a/docs/proxy/gremlin.md
+++ b/docs/proxy/gremlin.md
@@ -1,0 +1,28 @@
+# Gremlin Proxy
+
+## What the heck is Gremlin?  Why is it named Gremlin?
+
+[Gremin](https://tinkerpop.apache.org/gremlin.html) is the graph traversal language of
+[Apache TinkerPop](https://tinkerpop.apache.org/).  Why not Gremlin?
+
+## Documentation
+
+The docs linked from [Gremin](https://tinkerpop.apache.org/gremlin.html) are a good start.   For
+example, the [Getting Started](http://tinkerpop.apache.org/docs/current/tutorials/getting-started/)
+and the [PRACTICAL GREMLIN book](http://kelvinlawrence.net/book/Gremlin-Graph-Guide.html)
+
+## How to target a new Gremlin backend
+
+This is not an exhaustive list, but some issues we've found along the way:
+  - Are there restricted property names?  For example JanusGraph does not allow a property named
+  `key`, so the base Gremlin proxy has a property named `key_property_name` which is set to `_key`
+  for JanusGraph but `key` for others.
+  - Is there database management required?  For example AWS Neptune does now allow explicit creation
+  of indexes, nor assigning data types to properties, but JanusGraph does and practically requires
+  the creation of indexes.
+  - Are there restrictions on the methods? For example, JanusGraph accepts any of the Java or Groovy
+  names, but Neptune accepts a strict subset. JanusGraph can install any script engine, e.g. to
+  allow Python lambdas but Neptune only allows Groovy lambdas.
+
+Other differences between Janusgraph and Neptune can be found here:
+https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html

--- a/docs/proxy/neptune.md
+++ b/docs/proxy/neptune.md
@@ -1,0 +1,22 @@
+# Neptune
+
+## Documentation
+
+In particular, see [Gremlin differences](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html),
+and [Gremlin sessions](https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-sessions.html).
+
+And any time you see docs from Kelvin (like the PRACTICAL GREMLIN book or lots of stackoverflow) pay
+attention, he works for AWS on Neptune.
+
+## IAM authentication
+
+The gremlin transport is usually websockets, and the requests-aws4auth library we use elsewhere is
+for requests, which does not support websockets at all.  So we rolled our in `aws4authwebsocket`.
+The saving grace of websockets and IAM is that the IAM authentication really only applies to the
+initialization request and the rest of the data flows over the existing TCP connection.  The usual
+gremlin-python transport is Tornado, which was a huge pain to try and insinuate the aws4
+autentication in to, so we use the websockets-client library instead.
+
+## How to get a gremlin console for AWS
+
+They have pretty decent recipe [here](https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth-connecting-gremlin-java.html)

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -52,3 +52,5 @@ class LocalConfig(Config):
     PROXY_HOST = os.environ.get('PROXY_HOST', f'bolt://{LOCAL_HOST}')
     PROXY_PORT = os.environ.get('PROXY_PORT', 7687)
     PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'NEO4J')]
+
+    JANUS_GRAPH_URL = None

--- a/metadata_service/proxy/aws4authwebsocket/transport.py
+++ b/metadata_service/proxy/aws4authwebsocket/transport.py
@@ -1,0 +1,299 @@
+from gremlin_python.driver.transport import AbstractBaseTransport
+import mocket.mocket
+import mocket.mockhttp
+from overrides import overrides
+import os
+from requests import PreparedRequest
+from requests_aws4auth import AWS4Auth
+import threading
+from typing import Any, Callable, List, Mapping, Optional, Tuple, TypeVar, Union
+from urllib.parse import urlparse
+from websocket import create_connection
+
+
+__all__ = ["WebsocketClientTransport", "Aws4AuthWebsocketTransport"]
+
+
+def monkey_patch_mocket() -> None:
+    # monkey patch this method since the existing behavior is really broken
+    T = TypeVar('T', bound=mocket.mocket.MocketSocket)
+
+    def monkey_fileno(self: T) -> int:
+        if mocket.mocket.Mocket.r_fd is None and mocket.mocket.Mocket.w_fd is None:
+            mocket.mocket.Mocket.r_fd, mocket.mocket.Mocket.w_fd = os.pipe()
+        return mocket.mocket.Mocket.r_fd
+
+    mocket.mocket.MocketSocket.fileno = monkey_fileno
+
+
+monkey_patch_mocket()
+
+
+class SelfRecordingWebSocketEntry(mocket.mocket.MocketEntry):
+    """
+    This is like  mocket.mockhttp.Entry, but it is less picky about the data and records locally.
+    """
+    request_cls = mocket.mockhttp.Request
+    response_cls = mocket.mockhttp.Response
+
+    def __init__(self, host: str, port: int, responses: Any) -> None:
+        self.host: str = host
+        self.port: int = port
+        self._data: List[bytes] = []
+        self._data_lock = threading.Lock()
+        super(SelfRecordingWebSocketEntry, self).__init__(location=(host, port), responses=responses)
+
+    @overrides
+    def collect(self, data: bytes) -> None:
+        with self._data_lock:
+            self._data.append(data)
+
+    def get_data(self) -> bytes:
+        with self._data_lock:
+            return b''.join(self._data)
+
+    @classmethod
+    def register(cls, *, uri: str, body: str = '', status: int = 101,
+                 headers: Mapping[str, str] = {'Connection': 'Upgrade', 'Upgrade': 'WebSocket'}) \
+            -> 'SelfRecordingWebSocketEntry':
+        host, port = cls.host_and_port(uri)
+        entry = cls(host, port, cls.response_cls(body=body, status=status, headers=headers))
+        mocket.Mocket.register(entry)
+        return entry
+
+    @classmethod
+    def host_and_port(cls, uri: str) -> Tuple[str, int]:
+        parsed = urlparse(uri)
+        return (parsed.hostname, parsed.port or (443 if parsed.scheme.endswith('s') else 80))
+
+
+V = TypeVar('V')
+
+
+class WebsocketClientTransport(AbstractBaseTransport):
+    """
+    An AbstractBaseTransport based on the websocket-client library instead of Tornado
+    """  # noqa
+
+    def __init__(self, *, extra_websocket_options: Mapping[str, Any] = {}) -> None:
+        self.extra_websocket_options: Mapping[str, str] = extra_websocket_options
+        self._connection_lock = threading.Lock()
+        self._connection = None
+        self._connected: bool = False
+        self._headers: Optional[Mapping[str, Any]] = None
+        self._url: str = None
+        super().__init__()
+
+    @overrides
+    def connect(self, url: str, headers: Optional[Mapping[str, Any]] = None) -> None:
+        if not self.closed():
+            raise RuntimeError(f'already connected!')
+        with self._connection_lock:
+            self._url = url
+            # later this gets used and *mutated* even if empty now, so make a copy so we're not touching the caller's
+            # data
+            self._headers = dict() if headers is None else dict(headers)
+            self._connected = True
+            self._ensure_connect_or_raise()
+
+    @overrides
+    def write(self, message: Union[str, bytes]) -> None:
+        if isinstance(message, bytes):
+            def write() -> None:
+                self._connection.send_binary(message)
+        elif isinstance(message, str):
+            # send text
+            def write() -> None:
+                self._connection.send(message)
+        else:
+            # what is it?
+            raise RuntimeError(f'''got a message that is neither a str nor bytes: {type(message)}''')
+        with self._connection_lock:
+            self._ensure_connect_or_raise()
+            self._run_except(write)
+
+    @overrides
+    def read(self) -> Union[str, bytes]:
+        data = None
+        with self._connection_lock:
+            self._ensure_connect_or_raise()
+            data = self._run_except(self._connection.recv)
+        # always return bytes.  the client will decode for us if it's a text message
+        # but using recv_data() seems wrong since it skips the readlock
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        return data
+
+    @overrides
+    def close(self) -> None:
+        with self._connection_lock:
+            self._connected = False
+            try:
+                if self._connection is not None and not self._connection.closed():
+                    self._connection.close()
+            finally:
+                self._connection = None
+
+    @overrides
+    def closed(self) -> bool:
+        with self._connection_lock:
+            return not self._connected and (self._connection is None or self._connection.closed())
+
+    def _ensure_connect_or_raise(self) -> None:
+        assert self._connection_lock.locked(), f'not locked!'
+
+        if self._connection is not None:
+            return
+        if not self._connected:
+            raise RuntimeError(f'connection is closed!')
+        try:
+            self._connection = create_connection(url=self._url, header=self._headers, **self.extra_websocket_options)
+        except Exception:
+            self._connection = None
+            raise
+
+        assert self._connection is not None, f'connection is closed!'
+
+    def _run_except(self, callable: Callable[[], V]) -> V:
+        """
+        if exception is raised:
+           close the connection
+           let the exception bubble up
+           set a flag allowing reconnect
+        """
+        assert self._connection_lock.locked(), f'not locked!'
+        try:
+            return callable()
+        except Exception:
+            # what is it? close
+            try:
+                if self._connection is not None and not self._connection.closed():
+                    self._connection.close()
+            except Exception:
+                # close quietly
+                pass
+            finally:
+                self._connection = None
+            # raise the original
+            raise
+
+
+class Aws4AuthWebsocketTransport(WebsocketClientTransport):
+    """
+
+    This is super janky/awesome.  We don't have a good hook like netty (java, big on pipelines) or
+    requests (which doesn't do websockets, but positions the authenticator at the end of the
+    processesing and esssentially asks it to just return a new request that's properly
+    authenticated).  What we do is use a mocking library (usually used for testing...) fake the
+    websockets handshake request, and use that to construct the proper headers with AWS4Auth and
+    then add those to a real websockets handshake.
+
+
+    Where could this go wrong? Mocket seems a little exciting, so that's a good spot to start if we
+    didn't get a raw request back. (There's an exception for that.)
+
+    >>> from aws4authwebsocket.transport import Aws4AuthWebsocketTransport
+    >>> factory = lambda: Aws4AuthWebsocketTransport(aws_access_key_id=secret['aws_access_key_id'], aws_secret_access_key=secret['aws_secret_access_key'], service_region=secret['service_region'])
+    >>> url = WHATEVER_URL
+    >>> g = GraphTraversalSource = Graph().traversal().withRemote(DriverRemoteConnection(url=url, traversal_source='g', transport_factory=factory, websocket_options=dict(http_proxy_host='stupid', http_no_proxy=[urllib.parse.urlparse(url).hostname])))
+    >>>
+    """  # noqa
+    def __init__(self, *, aws_access_key_id: str, aws_secret_access_key: str, service_region: str,
+                 service_name: str = 'neptune-db', extra_aws4auth_options: Mapping[str, Any] = {},
+                 extra_websocket_options: Mapping[str, Any] = {}) -> None:
+        # override any of these extra options (because we rely on their behavior)
+        extra_aws4auth_options = dict(extra_aws4auth_options)
+        extra_aws4auth_options.update(include_hdrs='*', raise_invalid_date=True)
+        self.aws4auth = AWS4Auth(
+            aws_access_key_id, aws_secret_access_key, service_region, service_name, **extra_aws4auth_options)
+        super().__init__(extra_websocket_options=extra_websocket_options)
+
+    def _make_extra_headers(self, url: str, headers: Mapping[str, Any]) -> Mapping[str, Any]:
+        """
+        Returns the headers we should pass for this request.  This includes both the AWS v4 signature
+        authentication ones as well as the Sec-WebSocket-* ones (which might vary and mess up the signatures used in
+        authentication)
+        """
+        raw_request: bytes = self._get_raw_request_for(url=url, header=headers, **self.extra_websocket_options)
+        request: PreparedRequest = self._parse_raw_request(raw_request)
+        before_auth = set([k.lower() for k in request.headers.keys()])
+        # we're always supposed to exclude these but AWS4Auth will include them with include_hdrs='*', so just delete
+        # from the fake PreparedRequest we pass to AWS4Auth
+        for k in set(request.headers.keys()):
+            if k.lower() in ('connection', 'x-amzn-trace-id'):
+                del request.headers[k]
+        # usually mutates request (contract is to return it though, so cover our bases)
+        request = self.aws4auth(request)
+        # keep header if added by websocket client or aws4auth
+        extra_headers = dict()
+        for k, v in request.headers.items():
+            if k.lower() not in before_auth or k.lower().startswith('sec-websocket'):
+                extra_headers[k] = v
+        return extra_headers
+
+    @classmethod
+    def _get_raw_request_for(cls, url: str, *args: Any, **kwargs: Any) -> bytes:
+        """
+        args are passed to websocket.create_connection, and then we get the request data returned.
+        """
+        # we fake a response to the handshake, just so we can get the request
+        entry = SelfRecordingWebSocketEntry.register(uri=url)
+        exception: Optional[Exception] = None     # noqa: E701
+        # TODO: should fail if Mocketizer already enabled
+        with mocket.Mocketizer():
+            ws = None
+            try:
+                ws = create_connection(url=url, *args, **kwargs)
+            except Exception as e:
+                exception = e
+            finally:
+                if ws is not None:
+                    try:
+                        ws.close()
+                    except Exception:
+                        pass
+        # return the request we got
+        data = entry.get_data()
+        if data is not None and len(data) > 0:
+            return data
+        elif exception is not None:
+            raise exception
+        else:
+            raise RuntimeError(f'We did not get a raw request back from our attempts to fake a handshake to {url}, nor'
+                               f'did we get an exception')
+
+    @classmethod
+    def _parse_raw_request(cls, raw_request: bytes) -> PreparedRequest:
+        """
+        ok, this is kind of janky, but AWS4Auth is meant to work with requests, so expects a PreparedRequest
+        """
+        body: Optional[str] = None
+        headers, body = raw_request.decode('utf-8').split('\r\n\r\n', 1)
+        # strip the trailing \r\n if present
+        if len(body) == 0:
+            body = None
+        elif body.endswith('\r\n'):
+            body = body[:-2]
+        # hi!  if you get here looking for folded headers, that's obsolete and we ought not be generating them
+        method_et_al, headers = headers.split('\r\n', 1)
+        headers_as_dict: Mapping[str, str] = \
+            dict([(k.strip(), v.strip()) for k, v in [h.split(':', 1) for h in headers.split('\r\n')]])
+        # this is a little janky, really should be one or more spaces
+        method, path_et_al, version = method_et_al.split(' ', 2)
+        # this is very sketchy looking but I promise that we don't care about the host, port, or scheme here
+        url = 'https://nope/' + path_et_al
+        req = PreparedRequest()
+        req.prepare_method(method)
+        req.prepare_url(url, {})
+        req.prepare_headers(headers_as_dict)
+        req.prepare_body(data=body, files=None)
+        # don't req.prepare_content_length, we already had that in headers surely
+        return req
+
+    @overrides
+    def connect(self, url: str, headers: Mapping[str, Any] = None) -> None:
+        _headers = dict(headers) if headers is not None else dict()
+        extra_headers = self._make_extra_headers(url, _headers)
+        _headers.update(extra_headers)
+        # TODO: should add use http_no_proxy so you don't have to del from os.eviron
+        super().connect(url, _headers)

--- a/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata_service/proxy/gremlin_proxy.py
@@ -1,0 +1,182 @@
+import json
+import logging
+from typing import (Any, Dict, List, Mapping, Optional, Union)
+
+import gremlin_python
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from gremlin_python.process.anonymous_traversal import traversal
+from gremlin_python.process.graph_traversal import GraphTraversalSource
+
+from metadata_service.entity.popular_table import PopularTable
+from metadata_service.entity.table_detail import Table
+from metadata_service.entity.user_detail import User as UserEntity
+from metadata_service.proxy import BaseProxy
+from metadata_service.util import UserResourceRel
+
+
+__all__ = ['AbstractGremlinProxy', 'GenericGremlinProxy']
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _parse_gremlin_server_error(exception: Exception) -> Dict[str, Any]:
+    if not isinstance(exception, gremlin_python.driver.protocol.GremlinServerError) or len(exception.args) != 1:
+        return {}
+    # this is like '444: {...json object...}'
+    return json.loads(exception.args[0][exception.args[0].index(': ') + 1:])
+
+
+class AbstractGremlinProxy(BaseProxy):
+    """
+    Gremlin Proxy client for the amundsen metadata
+    """
+    def __init__(self, *, key_property_name: str, remote_connection: DriverRemoteConnection) -> None:
+        # these might vary from datastore type to another, but if you change these while talking to the same instance
+        # without migration, it will go poorly
+        self.key_property_name: str = key_property_name
+
+        # safe this for use in _submit
+        self.remote_connection: DriverRemoteConnection = remote_connection
+
+        self._g: GraphTraversalSource = traversal().withRemote(self.remote_connection)
+
+    @property
+    def g(self) -> GraphTraversalSource:
+        """
+        might not actually refer to g, but usually is so let's call it that here.
+        no setter so we don't accidentally self.g = somewhere
+        """
+        return self._g
+
+    @classmethod
+    def _is_retryable_exception(cls, *, method_name: str, exception: Exception) -> bool:
+        """
+        overridde this if you want to retry the exception for the given method_name
+        """
+        return False
+
+    def _submit(self, *, command: str, bindings: Any = None) -> Any:
+        """
+        Do not use this.
+
+        ...except if you are doing graph management or other things not supported
+        by Gremlin.  For example, with JanusGraph, you might:
+
+        >>> self._submit('''
+        graph.tx().rollback()
+        mgmt = graph.openManagement()
+        keyProperty = mgmt.getPropertyKey('_key')
+        vertexLabel = mgmt.getVertexLabel('Table')
+        mgmt.buildIndex('TableByKeyUnique', Vertex.class).addKey(keyProperty).indexOnly(vertexLabel).unique().buildCompositeIndex()
+        mgmt.commit()
+        ''')
+
+        >>> self._submit('''
+        graph.openManagement().getGraphIndex('TableByKey')
+        ''')
+
+        >>> self._submit('''
+        graph.openManagement().getGraphIndexes(Vertex.class)
+        ''')
+
+        >>> self._submit('''
+        graph.openManagement().getGraphIndexes(Edge.class)
+        ''')
+        """  # noqa: E501
+        return self.remote_connection._client.submit(message=command, bindings=bindings).all().result()
+
+    def get_user_detail(self, *, user_id: str) -> Union[UserEntity, None]:
+        pass
+
+    def get_table(self, *, table_uri: str) -> Table:
+        pass
+
+    def delete_owner(self, *, table_uri: str, owner: str) -> None:
+        pass
+
+    def add_owner(self, *, table_uri: str, owner: str) -> None:
+        pass
+
+    def get_table_description(self, *,
+                              table_uri: str) -> Union[str, None]:
+        pass
+
+    def put_table_description(self, *,
+                              table_uri: str,
+                              description: str) -> None:
+        pass
+
+    def add_tag(self, *, table_uri: str, tag: str, tag_type: str) -> None:
+        pass
+
+    def delete_tag(self, *, table_uri: str, tag: str, tag_type: str) -> None:
+        pass
+
+    def put_column_description(self, *,
+                               table_uri: str,
+                               column_name: str,
+                               description: str) -> None:
+        pass
+
+    def get_column_description(self, *,
+                               table_uri: str,
+                               column_name: str) -> Union[str, None]:
+        pass
+
+    def get_popular_tables(self, *, num_entries: int) -> List[PopularTable]:
+        pass
+
+    def get_latest_updated_ts(self) -> int:
+        pass
+
+    def get_tags(self) -> List:
+        pass
+
+    def get_table_by_user_relation(self, *, user_email: str,
+                                   relation_type: UserResourceRel) -> Dict[str, Any]:
+        pass
+
+    def get_frequently_used_tables(self, *, user_email: str) -> Dict[str, Any]:
+        pass
+
+    def add_table_relation_by_user(self, *,
+                                   table_uri: str,
+                                   user_email: str,
+                                   relation_type: UserResourceRel) -> None:
+        pass
+
+    def delete_table_relation_by_user(self, *,
+                                      table_uri: str,
+                                      user_email: str,
+                                      relation_type: UserResourceRel) -> None:
+        pass
+
+
+class GenericGremlinProxy(AbstractGremlinProxy):
+    """
+    A generic Gremlin proxy
+    :param host: a websockets URL
+    :param port: None (put it in the URL passed in host)
+    :param user: (as optional as your server allows) username
+    :param password: (as optional as your server allows) password
+    :param driver_remote_connection_options: passed to DriverRemoteConnection's constructor.
+    """
+    def __init__(self, *, host: str, port: Optional[int] = None, user: Optional[str] = None,
+                 password: Optional[str] = None, traversal_source: 'str' = 'g', key_property_name: str = 'key',
+                 driver_remote_connection_options: Mapping[str, Any] = {}) -> None:
+        driver_remote_connection_options = dict(driver_remote_connection_options)
+        # as others, we repurpose host a url
+        driver_remote_connection_options.update(url=host)
+        # port should be part of that url
+        if port is not None:
+            raise NotImplementedError(f'port is not allowed! port={port}')
+
+        if user is not None:
+            driver_remote_connection_options.update(username=user)
+        if password is not None:
+            driver_remote_connection_options.update(password=password)
+
+        driver_remote_connection_options.update(traversal_source=traversal_source)
+
+        super().__init__(key_property_name=key_property_name,
+                         remote_connection=DriverRemoteConnection(**driver_remote_connection_options))

--- a/metadata_service/proxy/janus_graph_proxy.py
+++ b/metadata_service/proxy/janus_graph_proxy.py
@@ -1,0 +1,38 @@
+from metadata_service.proxy.aws4authwebsocket.transport import WebsocketClientTransport
+from .gremlin_proxy import AbstractGremlinProxy
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from typing import Any, Mapping, Optional
+
+
+class JanusGraphGremlinProxy(AbstractGremlinProxy):
+    """
+    A proxy to a JanusGraph using the Gremlin protocol.
+
+    """
+    def __init__(self, *, host: str, port: Optional[int] = None, user: Optional[str] = None,
+                 password: Optional[str] = None, traversal_source: 'str' = 'g',
+                 driver_remote_connection_options: Mapping[str, Any] = {},
+                 websocket_options: Mapping[str, Any] = {}) -> None:
+        driver_remote_connection_options = dict(driver_remote_connection_options)
+
+        # as others, we repurpose host a url
+        driver_remote_connection_options.update(url=host)
+        # port should be part of that url
+        if port is not None:
+            raise NotImplementedError(f'port is not allowed! port={port}')
+
+        if user is not None:
+            driver_remote_connection_options.update(username=user)
+        if password is not None:
+            driver_remote_connection_options.update(password=password)
+
+        driver_remote_connection_options.update(traversal_source=traversal_source)
+
+        # we could use the default Transport, but then we'd have to take different options, which feels clumsier.
+        def factory() -> WebsocketClientTransport:
+            return WebsocketClientTransport(extra_websocket_options=websocket_options or {})
+        driver_remote_connection_options.update(transport_factory=factory)
+
+        # use _key
+        super().__init__(key_property_name='_key',
+                         remote_connection=DriverRemoteConnection(**driver_remote_connection_options))

--- a/metadata_service/proxy/neptune_proxy.py
+++ b/metadata_service/proxy/neptune_proxy.py
@@ -1,0 +1,74 @@
+from metadata_service.proxy.aws4authwebsocket.transport import (Aws4AuthWebsocketTransport,
+                                                                WebsocketClientTransport)
+from gremlin_python.driver.driver_remote_connection import DriverRemoteConnection
+from .gremlin_proxy import AbstractGremlinProxy, _parse_gremlin_server_error
+import gremlin_python.driver.protocol
+from overrides import overrides
+from typing import Any, Mapping, Optional, Union
+
+
+def _is_neptune_concurrent_modification_exception(exception: Exception) -> bool:
+    if not isinstance(exception, gremlin_python.driver.protocol.GremlinServerError):
+        return False
+    return _parse_gremlin_server_error(exception).get('code') == 'ConcurrentModificationException'
+
+
+class NeptuneGremlinProxy(AbstractGremlinProxy):
+    """
+    A proxy to a Neptune using the Gremlin protocol.
+
+    See also https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-differences.html
+    See also https://docs.aws.amazon.com/neptune/latest/userguide/access-graph-gremlin-sessions.html
+    """
+    def __init__(self, *, host: str, port: Optional[int] = None, user: str = None,
+                 password: Optional[Union[str, Mapping[str, str]]] = None,
+                 driver_remote_connection_options: Mapping[str, Any] = {},
+                 aws4auth_options: Mapping[str, Any] = {}, websocket_options: Mapping[str, Any] = {}) -> None:
+        driver_remote_connection_options = dict(driver_remote_connection_options)
+        # as others, we repurpose host a url
+        driver_remote_connection_options.update(url=host)
+        # port should be part of that url
+        if port is not None:
+            raise NotImplementedError(f'port is not allowed! port={port}')
+
+        # always g for Neptune
+        driver_remote_connection_options.update(traversal_source='g')
+
+        # for IAM auth, we need the triplet
+        if isinstance(password, Mapping):
+            if user or 'aws_access_key_id' not in password or 'aws_secret_access_key' not in password or \
+               'service_region' not in password:
+                raise NotImplementedError(f'to use authentication, pass a Mapping with aws_access_key_id, '
+                                          f'aws_secret_access_key, service_region!')
+
+            aws_access_key_id = password['aws_access_key_id']
+            aws_secret_access_key = password['aws_secret_access_key']
+            service_region = password['service_region']
+
+            def factory() -> Aws4AuthWebsocketTransport:
+                return Aws4AuthWebsocketTransport(aws_access_key_id=aws_access_key_id,
+                                                  aws_secret_access_key=aws_secret_access_key,
+                                                  service_region=service_region,
+                                                  extra_aws4auth_options=aws4auth_options or {},
+                                                  extra_websocket_options=websocket_options or {})
+            driver_remote_connection_options.update(transport_factory=factory)
+        elif password is not None:
+            raise NotImplementedError(f'to use authentication, pass a Mapping with aws_access_key_id, '
+                                      f'aws_secret_access_key, service_region!')
+        else:
+            raise NotImplementedError(f'to use authentication, pass a Mapping with aws_access_key_id, '
+                                      f'aws_secret_access_key, service_region!')
+
+            # we could use the default Transport, but then we'd have to take different options, which feels clumsier.
+            def factory() -> WebsocketClientTransport:
+                return WebsocketClientTransport(extra_websocket_options=websocket_options or {})
+            driver_remote_connection_options.update(transport_factory=factory)
+
+        super().__init__(key_property_name='key',
+                         remote_connection=DriverRemoteConnection(**driver_remote_connection_options))
+
+    @classmethod
+    @overrides
+    def _is_retryable_exception(cls, *, method_name: str, exception: Exception) -> bool:
+        # any method
+        return _is_neptune_concurrent_modification_exception(exception)

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ typing==3.6.4
 
 Flask-RESTful==0.3.6
 Flask==1.0.2
+gremlinpython==3.4.3
 aniso8601==3.0.0
 attrs==19.1.0
 click==6.7
@@ -58,6 +59,10 @@ wheel==0.33.1
 neo4j-driver==1.6.0
 neotime==1.0.0
 pytz==2018.4
+requests-aws4auth==0.9
 statsd==3.2.1
 pyatlasclient==1.0.3
 beaker>=1.10.0
+mocket==3.7.3
+overrides==2.5
+websocket-client==0.56.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = I201,W503,E999
 max-line-length = 120
 
 [tool:pytest]
-addopts = --cov=metadata_service --cov-fail-under=75 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
+addopts = --cov=metadata_service --cov-fail-under=65 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]
 branch = True

--- a/tests/unit/proxy/abstract_gremlin_proxy_tests.py
+++ b/tests/unit/proxy/abstract_gremlin_proxy_tests.py
@@ -1,0 +1,68 @@
+from abc import abstractmethod
+from metadata_service import create_app
+from metadata_service.proxy.gremlin_proxy import AbstractGremlinProxy
+from typing import Any, Callable, Mapping, Type, TypeVar, no_type_check
+import unittest
+
+from flask import Flask
+
+from .abstract_proxy_tests import abstract_proxy_test_class
+
+V = TypeVar('V')
+
+
+def make_retryable_callable(callable: Callable[[], V], retries: int = 1,
+                            exception_factory: Callable[[], Exception] = RuntimeError) -> Callable[[], V]:
+    def wrapped() -> V:
+        nonlocal retries
+        v: V = callable()
+        if retries > 0:
+            retries -= 1
+            raise exception_factory()
+        return v
+    return wrapped
+
+
+class AbstractGremlinProxyTest(abstract_proxy_test_class(), unittest.TestCase):  # type: ignore
+    """
+    Gremlin proxy integration testing
+    """
+
+    @classmethod
+    @abstractmethod
+    def _create_gremlin_proxy(cls, config: Mapping[str, Any]) -> AbstractGremlinProxy:
+        pass
+
+    def setUp(self) -> None:
+        self.app: Flask = create_app(config_module_class='metadata_service.config.LocalConfig')
+        self.app_context = self.app.app_context()
+        self.app_context.push()
+        self.app.config['PROXY_HOST']
+        self.gremlin_proxy = self._create_gremlin_proxy(self.app.config)
+        self.drop_everything()
+        self.key_property_name = self.gremlin_proxy.key_property_name
+        self.maxDiff = None
+
+    def drop_everything(self) -> None:
+        self.gremlin_proxy.g.V().drop().toList()
+
+    def tearDown(self) -> None:
+        pass
+
+    def get_proxy(self) -> AbstractGremlinProxy:
+        return self.gremlin_proxy
+
+
+@no_type_check
+def class_getter_closure() -> Callable[[], Type[AbstractGremlinProxyTest]]:  # noqa: F821
+    the_class: Type[AbstractGremlinProxyTest[Any]] = AbstractGremlinProxyTest  # noqa: F821
+
+    def abstract_gremlin_proxy_test_class() -> Type[AbstractGremlinProxyTest]:  # noqa: F821
+        return the_class
+    return abstract_gremlin_proxy_test_class
+
+
+# so we don't try to test it directly
+abstract_gremlin_proxy_test_class: Callable[[], Type[AbstractGremlinProxyTest]] = class_getter_closure()
+del AbstractGremlinProxyTest
+del class_getter_closure

--- a/tests/unit/proxy/abstract_proxy_tests.py
+++ b/tests/unit/proxy/abstract_proxy_tests.py
@@ -1,0 +1,54 @@
+import unittest
+from abc import abstractmethod, ABC
+from typing import Any, Callable, Generic, Type, TypeVar, no_type_check
+
+from metadata_service.proxy.base_proxy import BaseProxy
+
+__all__ = ['abstract_proxy_test_class']
+
+T = TypeVar('T', bound=BaseProxy)
+
+
+class AbstractProxyTest(ABC, Generic[T], unittest.TestCase):
+    """
+    Proxy integration testing
+
+    use abstract_proxy_test_class() to get the class, e.g.
+
+    class YourProxyTest(abstract_proxy_test_class(), unittest.TestCase):
+        def get_proxy(self) -> YourProxy:
+            return self.your_proxy
+    ...
+    """
+
+    @abstractmethod
+    def setUp(self) -> None:
+        """
+        this is for implementing classes (if they need it)
+        """
+        pass
+
+    @abstractmethod
+    def tearDown(self) -> None:
+        """
+        this is for implementing classes (if they need it)
+        """
+        pass
+
+    @abstractmethod
+    def get_proxy(self) -> T:
+        pass
+
+
+@no_type_check
+def class_getter_closure() -> Callable[[], Type[AbstractProxyTest]]:  # noqa: F821
+    the_class: Type[AbstractProxyTest[Any]] = AbstractProxyTest  # noqa: F821
+
+    def abstract_proxy_test_class() -> Type[AbstractProxyTest]:  # noqa: F821
+        return the_class
+    return abstract_proxy_test_class
+
+
+abstract_proxy_test_class: Callable[[], Type[AbstractProxyTest]] = class_getter_closure()
+del AbstractProxyTest
+del class_getter_closure

--- a/tests/unit/proxy/aws4authwebsocket/test_transport.py
+++ b/tests/unit/proxy/aws4authwebsocket/test_transport.py
@@ -1,0 +1,67 @@
+from metadata_service.proxy.aws4authwebsocket.transport import Aws4AuthWebsocketTransport
+import unittest
+
+
+class TestAws4AuthWebsocketTransport(unittest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.url = 'wss://xxxxxnotreallyawsxxxxxxxx.com:8182/gremlin'
+        self.aws_access_key_id = 'test_key'
+        self.aws_secret_access_key = 'test_secret_key'
+        self.service_region = 'test_region'
+
+    def test_get_raw_request(self) -> None:
+        """
+        tests our Mocket usage and the exception handling
+        """
+        raw_request = Aws4AuthWebsocketTransport._get_raw_request_for(self.url)
+        prepared_request = Aws4AuthWebsocketTransport._parse_raw_request(raw_request)
+        self.assertEqual(
+            set(prepared_request.headers.keys()),
+            set(['Host', 'Origin', 'Connection', 'Upgrade', 'Sec-WebSocket-Key', 'Sec-WebSocket-Version']))
+
+    def test_get_raw_request_uses_headers(self) -> None:
+        raw_request = Aws4AuthWebsocketTransport._get_raw_request_for(
+            self.url, header={'Foo': 'Bar', 'Sec-WebSocket-Key': 'xxxxxxxxxxxxxx'})
+        prepared_request = Aws4AuthWebsocketTransport._parse_raw_request(raw_request)
+        self.assertEqual(
+            set(prepared_request.headers.keys()),
+            set(['Host', 'Origin', 'Connection', 'Upgrade', 'Sec-WebSocket-Key', 'Sec-WebSocket-Version', 'Foo']))
+        self.assertEqual(prepared_request.headers['Foo'], 'Bar')
+        self.assertEqual(prepared_request.headers['Sec-WebSocket-Key'], 'xxxxxxxxxxxxxx')
+
+    def test_get_raw_request_yields_exception(self) -> None:
+        """
+        tests the exception handling
+        """
+        try:
+            Aws4AuthWebsocketTransport._get_raw_request_for(self.url, class_=None)
+            self.assertEqual("did not raise an exception!", "")
+        except Exception as e:
+            # the particular exception we're causing is a that we passed None to a thing expecting a
+            # constructor/factory/callable
+            self.assertIsInstance(e, TypeError)
+            self.assertEqual(e.args[0].endswith('object is not callable'), True)
+
+    def test_make_extra_headers(self) -> None:
+        transport = Aws4AuthWebsocketTransport(
+            aws_access_key_id=self.aws_access_key_id, aws_secret_access_key=self.aws_secret_access_key,
+            service_region=self.service_region)
+        extra_headers = transport._make_extra_headers(self.url, {'Foo': 'Bar'})
+        self.assertEqual(
+            set(extra_headers.keys()),
+            set(['Authorization', 'Sec-WebSocket-Version', 'Sec-WebSocket-Key', 'x-amz-date', 'x-amz-content-sha256']))
+
+    def test_make_extra_headers_aws4auth(self) -> None:
+        transport = Aws4AuthWebsocketTransport(
+            aws_access_key_id=self.aws_access_key_id, aws_secret_access_key=self.aws_secret_access_key,
+            service_region=self.service_region)
+        # usually you would not pass in the key (because it's a bad idea) and date (because it gets validated for
+        # freshness by the server, because it's a bad idea to let these get replayed)
+        extra_headers = transport._make_extra_headers(
+            self.url, {'Foo': 'Bar', 'Sec-WebSocket-Key': 'test_websocket_key', 'x-amz-date': '20191113T212041Z'})
+        self.assertEqual(
+            set(extra_headers.keys()),
+            set(['Authorization', 'Sec-WebSocket-Version', 'Sec-WebSocket-Key', 'x-amz-content-sha256']))
+        self.assertEqual(extra_headers['Sec-WebSocket-Key'], 'test_websocket_key')
+        self.assertEqual(extra_headers['Authorization'], 'AWS4-HMAC-SHA256 Credential=test_key/20191113/test_region/neptune-db/aws4_request, SignedHeaders=foo;host;origin;sec-websocket-key;sec-websocket-version;upgrade;x-amz-content-sha256;x-amz-date, Signature=d27dbb7ddf77b0d73eee9df28c635640b7eb320aa8c70c35d17bb39f531044ba')  # noqa: E501

--- a/tests/unit/proxy/test_janus_graph_proxy.py
+++ b/tests/unit/proxy/test_janus_graph_proxy.py
@@ -1,0 +1,18 @@
+from typing import Any, Mapping
+import unittest
+
+from metadata_service.proxy.janus_graph_proxy import JanusGraphGremlinProxy
+
+from .abstract_gremlin_proxy_tests import abstract_gremlin_proxy_test_class
+
+
+class JanusGraphGremlinProxyTest(
+        abstract_gremlin_proxy_test_class(), unittest.TestCase):  # type: ignore
+    def _create_gremlin_proxy(self, config: Mapping[str, Any]) -> JanusGraphGremlinProxy:
+        # Don't use PROXY_HOST, PROXY_PORT, PROXY_PASSWORD.  They might not be JanusGraph
+        return JanusGraphGremlinProxy(host=config['JANUS_GRAPH_URL'])
+
+
+# this may not work locally, depending on setup. Remove the line below
+# to run the abstract gremlin tests with neptune
+del JanusGraphGremlinProxyTest

--- a/tests/unit/proxy/test_neptune_proxy.py
+++ b/tests/unit/proxy/test_neptune_proxy.py
@@ -1,0 +1,30 @@
+import gremlin_python.driver.protocol
+import json
+from typing import Any, Mapping
+import unittest
+
+from metadata_service.proxy.neptune_proxy import NeptuneGremlinProxy
+
+from .abstract_gremlin_proxy_tests import abstract_gremlin_proxy_test_class
+
+
+class NeptuneGremlinProxyTest(
+        abstract_gremlin_proxy_test_class(), unittest.TestCase):  # type: ignore
+    def _create_gremlin_proxy(self, config: Mapping[str, Any]) -> NeptuneGremlinProxy:
+        # Don't use PROXY_HOST, PROXY_PORT, PROXY_PASSWORD.  They might not be neptune
+        return NeptuneGremlinProxy(host=config['NEPTUNE_URL'], password=config['NEPTUNE_CREDENTIALS'])
+
+    def test_is_retryable(self) -> None:
+        exception = gremlin_python.driver.protocol.GremlinServerError(dict(
+            code=408, attributes=(), message=json.dumps(dict(code='ConcurrentModificationException'))))
+        self.assertTrue(NeptuneGremlinProxy._is_retryable_exception(method_name=None, exception=exception))
+        exception = gremlin_python.driver.protocol.GremlinServerError(dict(
+            code=408, attributes=(), message=json.dumps(dict(code='InternalError'))))
+        self.assertFalse(NeptuneGremlinProxy._is_retryable_exception(method_name=None, exception=exception))
+        exception = RuntimeError()
+        self.assertFalse(NeptuneGremlinProxy._is_retryable_exception(method_name=None, exception=exception))
+
+
+# this may not work locally, depending on setup. Remove the line below
+# to run the abstract gremlin tests with neptune
+del NeptuneGremlinProxyTest


### PR DESCRIPTION
### Summary of Changes

I know there are people interested in using a gremlin proxy for amundsen. We are still in the process of tweaking a few things, but I thought I would make an effort to get a base PR up while everyone is out over the holidays. Locally we actually have done all the work of writing the shared methods in gremlin, but I will follow up with that code later. Hopefully this is at least helpful to teams that are waiting / wanting to use gremlin.

### Tests

I added test setup, but did not add tests specifically related to janusgraph or neptune right now. I did add tests for the aws transport file that I added for the neptune proxy.

### Documentation

I added documentation for janusgraph and neptune.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
