### PR TITLE
Increase test percentage minimum and add mypy checks to test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint:
 
 .PHONY: mypy
 mypy:
-	mypy --ignore-missing-imports --follow-imports=skip --strict-optional --warn-no-return metadata_service
+	mypy --ignore-missing-imports --follow-imports=skip --strict-optional --warn-no-return .
 
 .PHONY: test
 test: test_unit lint mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ ignore = I201,W503,E999
 max-line-length = 120
 
 [tool:pytest]
-addopts = --cov=metadata_service --cov-fail-under=0 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
+addopts = --cov=metadata_service --cov-fail-under=75 --cov-report=term-missing:skip-covered --cov-report=xml --cov-report=html -vvv
 
 [coverage:run]
 branch = True

--- a/tests/unit/api/test_column_description_api.py
+++ b/tests/unit/api/test_column_description_api.py
@@ -17,7 +17,7 @@ class TestColumnDescriptionAPI(BasicTestCase):
         self.mock_client = patch('metadata_service.api.column.get_proxy_client')
         self.mock_proxy = self.mock_client.start().return_value = Mock()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
 
         self.mock_client.stop()

--- a/tests/unit/api/test_popular_tables_api.py
+++ b/tests/unit/api/test_popular_tables_api.py
@@ -24,7 +24,7 @@ class TestColumnDescriptionAPI(BasicTestCase):
         self.mock_client = patch('metadata_service.api.popular_tables.get_proxy_client')
         self.mock_proxy = self.mock_client.start().return_value = Mock()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         super().tearDown()
 
         self.mock_client.stop()

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -52,7 +52,7 @@ class Data:
         },
 
     }
-    column_metadata_entity['relationshipAttributes']['column'] = test_column
+    column_metadata_entity['relationshipAttributes']['column'] = test_column    # type: ignore
 
     db_entity = {
         'guid': '-100',
@@ -96,7 +96,7 @@ class Data:
         },
     }
     entity1.update(classification_entity)
-    metadata1['relationshipAttributes']['table'] = entity1
+    metadata1['relationshipAttributes']['table'] = entity1    # type: ignore
 
     metadata2 = {
         'guid': '-2',
@@ -126,7 +126,7 @@ class Data:
         },
     }
     entity2.update(classification_entity)
-    metadata2['relationshipAttributes']['table'] = entity2
+    metadata2['relationshipAttributes']['table'] = entity2    # type: ignore
 
     entities = {
         'entities': [

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -3,17 +3,19 @@ import unittest
 
 from atlasclient.exceptions import BadRequest
 from mock import patch, MagicMock
+from typing import Any, cast, Dict, Optional
 
 from metadata_service import create_app
 from metadata_service.entity.popular_table import PopularTable
 from metadata_service.entity.table_detail import (Table, User, Tag, Column, Statistics)
 from metadata_service.entity.tag_detail import TagDetail
 from metadata_service.exception import NotFoundException
+from metadata_service.util import UserResourceRel
 from tests.unit.proxy.fixtures.atlas_test_data import Data
 
 
 class TestAtlasProxy(unittest.TestCase, Data):
-    def setUp(self):
+    def setUp(self) -> None:
         self.app = create_app(config_module_class='metadata_service.config.LocalConfig')
         self.app_context = self.app.app_context()
         self.app_context.push()
@@ -25,15 +27,15 @@ class TestAtlasProxy(unittest.TestCase, Data):
             self.proxy = AtlasProxy(host='DOES_NOT_MATTER', port=0000)
             self.proxy._driver = MagicMock()
 
-    def to_class(self, entity):
+    def to_class(self, entity: Dict) -> Any:
         class ObjectView(object):
-            def __init__(self, dictionary):
+            def __init__(self, dictionary: Dict):
                 self.__dict__ = dictionary
 
         return ObjectView(entity)
 
-    def _mock_get_table_entity(self, entity=None):
-        entity = entity or self.entity1
+    def _mock_get_table_entity(self, entity: Optional[Any] = None) -> Any:
+        entity = cast(dict, entity or self.entity1)
         mocked_entity = MagicMock()
         mocked_entity.entity = entity
         if mocked_entity.entity == self.entity1:
@@ -43,7 +45,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
             }
         else:
             mocked_entity.referredEntities = {}
-        self.proxy._get_table_entity = MagicMock(return_value=(mocked_entity, {
+        self.proxy._get_table_entity = MagicMock(return_value=(mocked_entity, {    # type: ignore
             'entity': self.entity_type,
             'cluster': self.cluster,
             'db': self.db,
@@ -51,14 +53,14 @@ class TestAtlasProxy(unittest.TestCase, Data):
         }))
         return mocked_entity
 
-    def _mock_get_reader_entity(self, entity=None):
+    def _mock_get_reader_entity(self, entity: Optional[Any] = None) -> Any:
         entity = entity or self.entity1
         mocked_entity = MagicMock()
         mocked_entity.entity = entity
-        self.proxy._get_reader_entity = MagicMock(return_value=mocked_entity)
+        self.proxy._get_reader_entity = MagicMock(return_value=mocked_entity)    # type: ignore
         return mocked_entity
 
-    def test_extract_table_uri_info(self):
+    def test_extract_table_uri_info(self) -> None:
         table_info = self.proxy._extract_info_from_uri(table_uri=self.table_uri)
         self.assertDictEqual(table_info, {
             'entity': self.entity_type,
@@ -67,7 +69,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
             'name': self.name
         })
 
-    def test_get_ids_from_basic_search(self):
+    def test_get_ids_from_basic_search(self) -> None:
         entity1 = MagicMock()
         entity1.guid = self.entity1['guid']
 
@@ -82,7 +84,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
         expected = ['1', '2']
         self.assertListEqual(response, expected)
 
-    def test_get_table_entity(self):
+    def test_get_table_entity(self) -> None:
         unique_attr_response = MagicMock()
 
         self.proxy._driver.entity_unique_attribute = MagicMock(
@@ -96,15 +98,15 @@ class TestAtlasProxy(unittest.TestCase, Data):
         })
         self.assertEqual(ent.__repr__(), unique_attr_response.__repr__())
 
-    def test_get_table(self):
+    def test_get_table(self) -> None:
         self._mock_get_table_entity()
         response = self.proxy.get_table(table_uri=self.table_uri)
 
         classif_name = self.classification_entity['classifications'][0]['typeName']
-        ent_attrs = self.entity1['attributes']
+        ent_attrs = cast(dict, self.entity1['attributes'])
 
-        col_attrs = self.test_column['attributes']
-        col_metadata_attrs = self.column_metadata_entity['attributes']
+        col_attrs = cast(dict, self.test_column['attributes'])
+        col_metadata_attrs = cast(dict, self.column_metadata_entity['attributes'])
         exp_col_stats = list()
 
         for stats in col_metadata_attrs['statistics']:
@@ -129,15 +131,15 @@ class TestAtlasProxy(unittest.TestCase, Data):
                          description=ent_attrs['description'],
                          owners=[User(email=ent_attrs['owner'])],
                          columns=[exp_col],
-                         last_updated_timestamp=self.entity1['updateTime'])
+                         last_updated_timestamp=cast(int, self.entity1['updateTime']))
         self.assertEqual(str(expected), str(response))
 
-    def test_get_table_not_found(self):
+    def test_get_table_not_found(self) -> None:
         with self.assertRaises(NotFoundException):
             self.proxy._driver.entity_unique_attribute = MagicMock(side_effect=Exception('Boom!'))
             self.proxy.get_table(table_uri=self.table_uri)
 
-    def test_get_table_missing_info(self):
+    def test_get_table_missing_info(self) -> None:
         with self.assertRaises(BadRequest):
             local_entity = copy.deepcopy(self.entity1)
             local_entity.pop('attributes')
@@ -147,9 +149,9 @@ class TestAtlasProxy(unittest.TestCase, Data):
             self.proxy._driver.entity_unique_attribute = MagicMock(return_value=unique_attr_response)
             self.proxy.get_table(table_uri=self.table_uri)
 
-    def test_get_popular_tables(self):
-        meta1 = copy.deepcopy(self.metadata1)
-        meta2 = copy.deepcopy(self.metadata2)
+    def test_get_popular_tables(self) -> None:
+        meta1: Dict = copy.deepcopy(self.metadata1)
+        meta2: Dict = copy.deepcopy(self.metadata2)
 
         meta1['attributes']['table'] = self.entity1
         meta2['attributes']['table'] = self.entity2
@@ -178,8 +180,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
             self.assertEqual(self.proxy._driver.entity_bulk.call_count, 1)
 
-            ent1_attrs = self.entity1['attributes']
-            ent2_attrs = self.entity2['attributes']
+            ent1_attrs = cast(dict, self.entity1['attributes'])
+            ent2_attrs = cast(dict, self.entity2['attributes'])
 
             expected = [
                 PopularTable(database=self.entity_type, cluster=self.cluster, schema=self.db,
@@ -191,9 +193,9 @@ class TestAtlasProxy(unittest.TestCase, Data):
             self.assertEqual(expected.__repr__(), response.__repr__())
 
     # noinspection PyTypeChecker
-    def test_get_popular_tables_without_db(self):
-        meta1 = copy.deepcopy(self.metadata1)
-        meta2 = copy.deepcopy(self.metadata2)
+    def test_get_popular_tables_without_db(self) -> None:
+        meta1: Dict = copy.deepcopy(self.metadata1)
+        meta2: Dict = copy.deepcopy(self.metadata2)
 
         meta1['attributes']['table'] = self.entity1
         meta2['attributes']['table'] = self.entity2
@@ -207,8 +209,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
         result = MagicMock(return_value=metadata_collection)
 
         with patch.object(self.proxy._driver.search_basic, 'create', result):
-            entity1 = copy.deepcopy(self.entity1)
-            entity2 = copy.deepcopy(self.entity2)
+            entity1: Dict = copy.deepcopy(self.entity1)
+            entity2: Dict = copy.deepcopy(self.entity2)
 
             for entity in [entity1, entity2]:
                 entity['attributes']['qualifiedName'] = entity['attributes']['name']
@@ -238,8 +240,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
             self.assertEqual(1, self.proxy._driver.entity_bulk.call_count)
 
-            ent1_attrs = self.entity1['attributes']
-            ent2_attrs = self.entity2['attributes']
+            ent1_attrs = cast(dict, self.entity1['attributes'])
+            ent2_attrs = cast(dict, self.entity2['attributes'])
 
             expected = [
                 PopularTable(database=self.entity_type, cluster='default', schema='default',
@@ -250,22 +252,23 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
             self.assertEqual(expected.__repr__(), response.__repr__())
 
-    def test_get_popular_tables_search_exception(self):
+    def test_get_popular_tables_search_exception(self) -> None:
         with self.assertRaises(NotFoundException):
             self.proxy._driver.entity_bulk = MagicMock(return_value=None)
             self.proxy._get_metadata_entities({'query': 'test'})
 
-    def test_get_table_description(self):
+    def test_get_table_description(self) -> None:
         self._mock_get_table_entity()
         response = self.proxy.get_table_description(table_uri=self.table_uri)
-        self.assertEqual(response, self.entity1['attributes']['description'])
+        attributes = cast(dict, self.entity1['attributes'])
+        self.assertEqual(response, attributes['description'])
 
-    def test_put_table_description(self):
+    def test_put_table_description(self) -> None:
         self._mock_get_table_entity()
         self.proxy.put_table_description(table_uri=self.table_uri,
                                          description="DOESNT_MATTER")
 
-    def test_get_tags(self):
+    def test_get_tags(self) -> None:
         tag_response = {
             'tagEntities': {
                 'PII': 3,
@@ -283,7 +286,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
         expected = [TagDetail(tag_name='PII', tag_count=3), TagDetail(tag_name='NON_PII', tag_count=2)]
         self.assertEqual(expected.__repr__(), response.__repr__())
 
-    def test_add_tag(self):
+    def test_add_tag(self) -> None:
         tag = "TAG"
         self._mock_get_table_entity()
 
@@ -293,7 +296,7 @@ class TestAtlasProxy(unittest.TestCase, Data):
                 data={'classification': {'typeName': tag}, 'entityGuids': [self.entity1['guid']]}
             )
 
-    def test_delete_tag(self):
+    def test_delete_tag(self) -> None:
         tag = "TAG"
         self._mock_get_table_entity()
         mocked_entity = MagicMock()
@@ -303,47 +306,48 @@ class TestAtlasProxy(unittest.TestCase, Data):
             self.proxy.delete_tag(table_uri=self.table_uri, tag=tag, tag_type='default')
             mock_execute.assert_called_with()
 
-    def test_add_owner(self):
+    def test_add_owner(self) -> None:
         owner = "OWNER"
         entity = self._mock_get_table_entity()
         with patch.object(entity, 'update') as mock_execute:
             self.proxy.add_owner(table_uri=self.table_uri, owner=owner)
             mock_execute.assert_called_with()
 
-    def test_get_column(self):
+    def test_get_column(self) -> None:
         self._mock_get_table_entity()
         response = self.proxy._get_column(
             table_uri=self.table_uri,
-            column_name=self.test_column['attributes']['name'])
+            column_name=cast(dict, self.test_column['attributes'])['name'])
         self.assertDictEqual(response, self.test_column)
 
-    def test_get_column_wrong_name(self):
+    def test_get_column_wrong_name(self) -> None:
         with self.assertRaises(NotFoundException):
             self._mock_get_table_entity()
             self.proxy._get_column(table_uri=self.table_uri, column_name='FAKE')
 
-    def test_get_column_no_referred_entities(self):
+    def test_get_column_no_referred_entities(self) -> None:
         with self.assertRaises(NotFoundException):
-            local_entity = self.entity2
+            local_entity: Dict = self.entity2
             local_entity['attributes']['columns'] = [{'guid': 'ent_2_col'}]
             self._mock_get_table_entity(local_entity)
             self.proxy._get_column(table_uri=self.table_uri, column_name='FAKE')
 
-    def test_get_column_description(self):
+    def test_get_column_description(self) -> None:
         self._mock_get_table_entity()
+        attributes = cast(dict, self.test_column['attributes'])
         response = self.proxy.get_column_description(
             table_uri=self.table_uri,
-            column_name=self.test_column['attributes']['name'])
-        self.assertEqual(response, self.test_column['attributes'].get('description'))
+            column_name=attributes['name'])
+        self.assertEqual(response, attributes.get('description'))
 
-    def test_put_column_description(self):
+    def test_put_column_description(self) -> None:
         self._mock_get_table_entity()
+        attributes = cast(dict, self.test_column['attributes'])
         self.proxy.put_column_description(table_uri=self.table_uri,
-                                          column_name=self.test_column['attributes']['name'],
+                                          column_name=attributes['name'],
                                           description='DOESNT_MATTER')
 
-    def test_get_table_by_user_relation(self):
-
+    def test_get_table_by_user_relation(self) -> None:
         reader1 = copy.deepcopy(self.reader_entity1)
         reader1 = self.to_class(reader1)
         reader_collection = MagicMock()
@@ -351,27 +355,27 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
         self.proxy._driver.search_basic.create = MagicMock(return_value=reader_collection)
         res = self.proxy.get_table_by_user_relation(user_email='test_user_id',
-                                                    relation_type='follow')
+                                                    relation_type=UserResourceRel.follow)
 
         expected = [PopularTable(database=Data.entity_type, cluster=Data.cluster, schema=Data.db,
                                  name=Data.name, description=None)]
 
         self.assertEqual(res, {'table': expected})
 
-    def test_add_resource_relation_by_user(self):
+    def test_add_resource_relation_by_user(self) -> None:
         reader_entity = self._mock_get_reader_entity()
         with patch.object(reader_entity, 'update') as mock_execute:
             self.proxy.add_table_relation_by_user(table_uri=self.table_uri,
                                                   user_email="test_user_id",
-                                                  relation_type='follow')
+                                                  relation_type=UserResourceRel.follow)
             mock_execute.assert_called_with()
 
-    def test_delete_resource_relation_by_user(self):
+    def test_delete_resource_relation_by_user(self) -> None:
         reader_entity = self._mock_get_reader_entity()
         with patch.object(reader_entity, 'update') as mock_execute:
             self.proxy.delete_table_relation_by_user(table_uri=self.table_uri,
                                                      user_email="test_user_id",
-                                                     relation_type='follow')
+                                                     relation_type=UserResourceRel.follow)
             mock_execute.assert_called_with()
 
 


### PR DESCRIPTION
### Summary of Changes

I am trying to make it easier for us (and everyone, I guess) to refresh from upstream code. I added mypy coverage to test files and cleaned up outstanding mypy issues in those files. I also upped the minimum test coverage to 75% from 0. Not sure when that number was cleared...

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
