### PR TITLE
change default port to 5002

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ pip3 install amundsen-metadata
 $ python3 metadata_service/metadata_wsgi.py
 
 -- In a different terminal, verify getting HTTP/1.0 200 OK
-$ curl -v http://localhost:5000/healthcheck
+$ curl -v http://localhost:5002/healthcheck
 ```
 
 ## Instructions to start the Metadata service from the source
@@ -36,19 +36,19 @@ $ python3 setup.py install
 $ python3 metadata_service/metadata_wsgi.py
 
 -- In a different terminal, verify getting HTTP/1.0 200 OK
-$ curl -v http://localhost:5000/healthcheck
+$ curl -v http://localhost:5002/healthcheck
 ```
 
 ## Instructions to start the service from Docker
 
 ```bash
 $ docker pull amundsendev/amundsen-metadata:latest
-$ docker run -p 5000:5000 amundsendev/amundsen-metadata
+$ docker run -p 5002:5002 amundsendev/amundsen-metadata
 # - alternative, for production environment with Gunicorn (see its homepage link below)
-$ ## docker run -p 5000:5000 amundsendev/amundsen-metadata gunicorn --bind 0.0.0.0:5000 metadata_service.metadata_wsgi
+$ ## docker run -p 5002:5002 amundsendev/amundsen-metadata gunicorn --bind 0.0.0.0:5002 metadata_service.metadata_wsgi
 
 -- In a different terminal, verify getting HTTP/1.0 200 OK
-$ curl -v http://localhost:5000/healthcheck
+$ curl -v http://localhost:5002/healthcheck
 ```
 
 
@@ -86,7 +86,7 @@ PROXY_PASSWORD = 'password' # or env CREDENTIALS_PROXY_PASSWORD
 To start the service with Atlas from Docker. Make sure you have `atlasserver` configured in DNS (or docker-compose)
 
 ```bash
-$ docker run -p 5000:5000 --env PROXY_CLIENT=ATLAS --env PROXY_PORT=21000 --env PROXY_HOST=atlasserver --env CREDENTIALS_PROXY_USER=atlasuser --env CREDENTIALS_PROXY_PASSWORD=password amundsen-metadata:latest
+$ docker run -p 5002:5002 --env PROXY_CLIENT=ATLAS --env PROXY_PORT=21000 --env PROXY_HOST=atlasserver --env CREDENTIALS_PROXY_USER=atlasuser --env CREDENTIALS_PROXY_PASSWORD=password amundsen-metadata:latest
 ```
 
 ---
@@ -101,7 +101,7 @@ The support for Apache Atlas is work in progress. For example, while Apache Atla
 
 ## API documentation
 
-We have Swagger documentation setup with OpenApi 3.0.2. This documentation is generated via Flasgger. When adding or updating an API please make sure to update the documentation. To see the documentation run the application locally and go to localhost:5000/apidocs/. Currently the documentation only works with local configuration.
+We have Swagger documentation setup with OpenApi 3.0.2. This documentation is generated via Flasgger. When adding or updating an API please make sure to update the documentation. To see the documentation run the application locally and go to localhost:5002/apidocs/. Currently the documentation only works with local configuration.
 
 ## Code structure
 Please visit [Code Structure](docs/structure.md) to read how different modules are structured in Amundsen Metadata service.

--- a/metadata_service/metadata_wsgi.py
+++ b/metadata_service/metadata_wsgi.py
@@ -11,4 +11,4 @@ application = create_app(
     or 'metadata_service.config.LocalConfig')
 
 if __name__ == '__main__':
-    application.run(host='0.0.0.0')
+    application.run(host='0.0.0.0', port=5002)


### PR DESCRIPTION
### Summary of Changes

Change the default port to 5002. Currently all wsgi try to start up with the default port, so it's easier/free to start up all 3 servers for local debugging if they each have a different port.

This is kind of speculative --  WDYT? If ya'll are like us, you've customized the port for your individual circumstances anyway, but if you're expecting the port to be 5000, this will cause some problems...

### Tests

Config/port change. No tests affected.

### Documentation

Changed port number to 5002.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
