### PR TITLE
Do not allow tag and badge to have same value

### DIFF
--- a/metadata_service/api/table.py
+++ b/metadata_service/api/table.py
@@ -193,9 +193,10 @@ class TableTagAPI(Resource):
         args = self.parser.parse_args()
         # use tag_type to distinguish between tag and badge
         tag_type = args.get('tag_type', 'default')
+
+        whitelist_badges = app.config.get('WHITELIST_BADGES', [])
         if tag_type == 'badge':
             # need to check whether the badge is part of the whitelist:
-            whitelist_badges = app.config.get('WHITELIST_BADGES', [])
             if tag not in whitelist_badges:
                 return \
                     {'message': 'The tag {} for table_uri {} with type {} '
@@ -204,6 +205,15 @@ class TableTagAPI(Resource):
                                                                       table_uri,
                                                                       tag_type)}, \
                     HTTPStatus.NOT_FOUND
+        else:
+            if tag in whitelist_badges:
+                return \
+                    {'message': 'The tag {} for table_uri {} with type {} '
+                                'is not added successfully as tag '
+                                'for it is reserved for badge'.format(tag,
+                                                                      table_uri,
+                                                                      tag_type)}, \
+                    HTTPStatus.CONFLICT
 
         try:
             self.client.add_tag(table_uri=table_uri,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.6'
+__version__ = '1.1.7'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/api/table/test_table_badge_api.py
+++ b/tests/unit/api/table/test_table_badge_api.py
@@ -1,0 +1,51 @@
+import unittest
+from http import HTTPStatus
+
+from mock import patch, Mock
+
+from tests.unit.test_basics import BasicTestCase
+
+TABLE_NAME = 'magic'
+BADGE_NAME = 'foo'
+TAG_NAME = 'bar'
+
+
+class TableTagAPI(BasicTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.mock_client = patch('metadata_service.api.table.get_proxy_client')
+        self.mock_proxy = self.mock_client.start().return_value = Mock()
+
+    def tearDown(self):
+        super().tearDown()
+
+        self.mock_client.stop()
+
+    def test_block_tag_on_reserved_badge_value(self) -> None:
+        self.app.config['WHITELIST_BADGES'] = [BADGE_NAME]
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/tag/{BADGE_NAME}')
+
+        self.assertEqual(response.status_code, HTTPStatus.CONFLICT)
+
+    def test_tag_on_unreserved_badge_value(self) -> None:
+        self.app.config['WHITELIST_BADGES'] = [BADGE_NAME]
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/tag/{TAG_NAME}')
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_badge_on_reserved_badge_value(self) -> None:
+        self.app.config['WHITELIST_BADGES'] = [BADGE_NAME]
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/tag/{BADGE_NAME}?tag_type=badge')
+
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_badge_on_unreserved_badge_value(self) -> None:
+        self.app.config['WHITELIST_BADGES'] = [BADGE_NAME]
+        response = self.app.test_client().put(f'/table/{TABLE_NAME}/tag/{TAG_NAME}?tag_type=badge')
+
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary of Changes

This PR is to not allow same Tag value and Badge value for Badge is special Tag.
Also, if it's allowed it would change the type existing badge or tag as value is the unique constraint of Neo4j.

### Tests

Integration test performed.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
