### PR TITLE
Switch from user_id to id in get_user method

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -282,7 +282,7 @@ class AtlasProxy(BaseProxy):
             )
         return sorted(columns, key=lambda item: item.sort_order)
 
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     def get_users(self) -> List[UserEntity]:

--- a/metadata_service/proxy/base_proxy.py
+++ b/metadata_service/proxy/base_proxy.py
@@ -14,7 +14,7 @@ class BaseProxy(metaclass=ABCMeta):
     the proxy clients available in the amundsen metadata service
     """
     @abstractmethod
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     @abstractmethod

--- a/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata_service/proxy/gremlin_proxy.py
@@ -85,7 +85,7 @@ class AbstractGremlinProxy(BaseProxy):
         """  # noqa: E501
         return self.remote_connection._client.submit(message=command, bindings=bindings).all().result()
 
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     def get_users(self) -> List[UserEntity]:

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -710,7 +710,7 @@ class Neo4jProxy(BaseProxy):
         return popular_tables
 
     @timer_with_counter
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         """
         Retrieve user detail based on user_id(email).
 
@@ -725,12 +725,12 @@ class Neo4jProxy(BaseProxy):
         """)
 
         record = self._execute_cypher_query(statement=query,
-                                            param_dict={'user_id': user_id})
+                                            param_dict={'user_id': id})
         single_result = record.single()
 
         if not single_result:
             raise NotFoundException('User {user_id} '
-                                    'not found in the graph'.format(user_id=user_id))
+                                    'not found in the graph'.format(user_id=id))
 
         record = single_result.get('user_record', {})
         manager_record = single_result.get('manager_record', {})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.8'
+__version__ = '1.1.8rc0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.8rc0'
+__version__ = '1.1.9rc0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/api/test_user.py
+++ b/tests/unit/api/test_user.py
@@ -20,7 +20,7 @@ class UserDetailAPITest(unittest.TestCase):
         self.mock_client.get_user.return_value = {}
         response = self.api.get(id='username')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.get_user.assert_called_once()
+        self.mock_client.get_user.assert_called_once_with(id='username')
 
     def test_gets(self) -> None:
         self.mock_client.get_users.return_value = []

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -511,7 +511,7 @@ class TestNeo4jProxy(unittest.TestCase):
                 }
             }
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            neo4j_user = neo4j_proxy.get_user(user_id='test_email')
+            neo4j_user = neo4j_proxy.get_user(id='test_email')
             self.assertEquals(neo4j_user.email, 'test_email')
 
     def test_get_users(self) -> None:
@@ -606,7 +606,7 @@ class TestNeo4jProxy(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             mock_execute.return_value.single.return_value = None
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            self.assertRaises(NotFoundException, neo4j_proxy.get_user, user_id='invalid_email')
+            self.assertRaises(NotFoundException, neo4j_proxy.get_user, id='invalid_email')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

A follow up to my previous PR, which adds a BaseAPI with some generic logic. That logic expects "id" as an argument for the "get" method. This PR replaces user_id with id. 

### Tests

I updated the user API test to use `assert_called_once_with` so that this bug can be caught in the future via automated testing.

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
