### PR TITLE
User_id to id

### DIFF
--- a/metadata_service/__init__.py
+++ b/metadata_service/__init__.py
@@ -94,15 +94,15 @@ def create_app(*, config_module_class: str) -> Flask:
                      '/user',
                      '/user/<path:id>')
     api.add_resource(UserFollowsAPI,
-                     '/user/<path:user_id>/follow/')
+                     '/user/<path:id>/follow/')
     api.add_resource(UserFollowAPI,
-                     '/user/<path:user_id>/follow/<resource_type>/<path:table_uri>')
+                     '/user/<path:id>/follow/<resource_type>/<path:table_uri>')
     api.add_resource(UserOwnsAPI,
-                     '/user/<path:user_id>/own/')
+                     '/user/<path:id>/own/')
     api.add_resource(UserOwnAPI,
-                     '/user/<path:user_id>/own/<resource_type>/<path:table_uri>')
+                     '/user/<path:id>/own/<resource_type>/<path:table_uri>')
     api.add_resource(UserReadsAPI,
-                     '/user/<path:user_id>/read/')
+                     '/user/<path:id>/read/')
     app.register_blueprint(api_bp)
 
     if app.config.get('SWAGGER_ENABLED'):

--- a/metadata_service/api/swagger_doc/user/follow_delete.yml
+++ b/metadata_service/api/swagger_doc/user/follow_delete.yml
@@ -3,7 +3,7 @@ Delete the user following information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/follow_get.yml
+++ b/metadata_service/api/swagger_doc/user/follow_get.yml
@@ -3,7 +3,7 @@ Gets the user following information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/follow_put.yml
+++ b/metadata_service/api/swagger_doc/user/follow_put.yml
@@ -3,7 +3,7 @@ Updates the user following information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/own_delete.yml
+++ b/metadata_service/api/swagger_doc/user/own_delete.yml
@@ -3,7 +3,7 @@ Delete the user owner information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/own_get.yml
+++ b/metadata_service/api/swagger_doc/user/own_get.yml
@@ -3,7 +3,7 @@ Delete the user owner information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/own_put.yml
+++ b/metadata_service/api/swagger_doc/user/own_put.yml
@@ -3,7 +3,7 @@ Update the user owner information
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/swagger_doc/user/read_get.yml
+++ b/metadata_service/api/swagger_doc/user/read_get.yml
@@ -3,7 +3,7 @@ Get tables a user read
 tags:
   - 'user'
 parameters:
-  - name: user_id
+  - name: id
     in: path
     example: 'roald9@example.org'
     type: string

--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -57,22 +57,22 @@ class UserFollowsAPI(Resource):
         self.client = get_proxy_client()
 
     @swag_from('swagger_doc/user/follow_get.yml')
-    def get(self, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+    def get(self, id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Return a list of resources that user has followed
 
-        :param user_id:
+        :param id:
         :return:
         """
         try:
-            resources = self.client.get_table_by_user_relation(user_email=user_id,
+            resources = self.client.get_table_by_user_relation(user_email=id,
                                                                relation_type=UserResourceRel.follow)
             if len(resources['table']) > 0:
                 return {'table': PopularTableSchema(many=True).dump(resources['table']).data}, HTTPStatus.OK
             return {'table': []}, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+            return {'message': f'user_id {id} does not exist'}, HTTPStatus.NOT_FOUND
 
         except Exception:
             LOGGER.exception('UserFollowAPI GET Failed')
@@ -89,52 +89,46 @@ class UserFollowAPI(Resource):
         self.client = get_proxy_client()
 
     @swag_from('swagger_doc/user/follow_put.yml')
-    def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
-        :param user_id:
+        :param id:
         :param table_uri:
         :return:
         """
         try:
             self.client.add_table_relation_by_user(table_uri=table_uri,
-                                                   user_email=user_id,
+                                                   user_email=id,
                                                    relation_type=UserResourceRel.follow)
-            return {'message': 'The user {} for table_uri {} '
-                               'is added successfully'.format(user_id,
-                                                              table_uri)}, HTTPStatus.OK
+            return {'message': f'The user {id} for table_uri {table_uri} '
+                               'is added successfully'}, HTTPStatus.OK
         except Exception as e:
             LOGGER.exception('UserFollowAPI PUT Failed')
-            return {'message': 'The user {} for table_uri {} '
-                               'is not added successfully'.format(user_id,
-                                                                  table_uri)}, \
-                HTTPStatus.INTERNAL_SERVER_ERROR
+            return {'message': f'The user {id} for table_uri {table_uri} '
+                               'is not added successfully'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     @swag_from('swagger_doc/user/follow_delete.yml')
-    def delete(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Delete the follow relationship between user and resources.
         todo: It will need to refactor all neo4j proxy api to take a type argument.
 
-        :param user_id:
+        :param id:
         :param table_uri:
         :return:
         """
         try:
             self.client.delete_table_relation_by_user(table_uri=table_uri,
-                                                      user_email=user_id,
+                                                      user_email=id,
                                                       relation_type=UserResourceRel.follow)
-            return {'message': 'The user following {} for table_uri {} '
-                               'is deleted successfully'.format(user_id,
-                                                                table_uri)}, HTTPStatus.OK
+            return {'message': f'The user following {id} for table_uri {table_uri} '
+                               'is deleted successfully'}, HTTPStatus.OK
         except Exception as e:
             LOGGER.exception('UserFollowAPI DELETE Failed')
-            return {'message': 'The user {} for table_uri {} '
-                               'is not deleted successfully'.format(user_id,
-                                                                    table_uri)}, \
-                HTTPStatus.INTERNAL_SERVER_ERROR
+            return {'message': f'The user {id} for table_uri {table_uri} '
+                               'is not deleted successfully'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class UserOwnsAPI(Resource):
@@ -146,22 +140,22 @@ class UserOwnsAPI(Resource):
         self.client = get_proxy_client()
 
     @swag_from('swagger_doc/user/own_get.yml')
-    def get(self, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+    def get(self, id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Return a list of resources that user has owned
 
-        :param user_id:
+        :param id:
         :return:
         """
         try:
-            resources = self.client.get_table_by_user_relation(user_email=user_id,
+            resources = self.client.get_table_by_user_relation(user_email=id,
                                                                relation_type=UserResourceRel.own)
             if len(resources['table']) > 0:
                 return {'table': PopularTableSchema(many=True).dump(resources['table']).data}, HTTPStatus.OK
             return {'table': []}, HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+            return {'message': f'user_id {id} does not exist'}, HTTPStatus.NOT_FOUND
 
         except Exception:
             LOGGER.exception('UserOwnAPI GET Failed')
@@ -179,38 +173,34 @@ class UserOwnAPI(Resource):
         self.client = get_proxy_client()
 
     @swag_from('swagger_doc/user/own_put.yml')
-    def put(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def put(self, id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Create the follow relationship between user and resources.
 
-        :param user_id:
+        :param id:
         :param resource_type:
         :param table_uri:
         :return:
         """
         try:
-            self.client.add_owner(table_uri=table_uri, owner=user_id)
-            return {'message': 'The owner {} for table_uri {} '
-                               'is added successfully'.format(user_id,
-                                                              table_uri)}, HTTPStatus.OK
+            self.client.add_owner(table_uri=table_uri, owner=id)
+            return {'message': f'The owner {id} for table_uri {table_uri} '
+                               'is added successfully'}, HTTPStatus.OK
         except Exception as e:
             LOGGER.exception('UserOwnAPI PUT Failed')
-            return {'message': 'The owner {} for table_uri {} '
-                               'is not added successfully'.format(user_id,
-                                                                  table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+            return {'message': f'The owner {id} for table_uri {table_uri} '
+                               'is not added successfully'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
     @swag_from('swagger_doc/user/own_delete.yml')
-    def delete(self, user_id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
+    def delete(self, id: str, resource_type: str, table_uri: str) -> Iterable[Union[Mapping, int, None]]:
         try:
-            self.client.delete_owner(table_uri=table_uri, owner=user_id)
-            return {'message': 'The owner {} for table_uri {} '
-                               'is deleted successfully'.format(user_id,
-                                                                table_uri)}, HTTPStatus.OK
+            self.client.delete_owner(table_uri=table_uri, owner=id)
+            return {'message': f'The owner {id} for table_uri {table_uri} '
+                               'is deleted successfully'}, HTTPStatus.OK
         except Exception:
             LOGGER.exception('UserOwnAPI DELETE Failed')
-            return {'message': 'The owner {} for table_uri {} '
-                               'is not deleted successfully'.format(user_id,
-                                                                    table_uri)}, HTTPStatus.INTERNAL_SERVER_ERROR
+            return {'message': f'The owner {id} for table_uri {table_uri} '
+                               'is not deleted successfully'}, HTTPStatus.INTERNAL_SERVER_ERROR
 
 
 class UserReadsAPI(Resource):
@@ -222,19 +212,19 @@ class UserReadsAPI(Resource):
         self.client = get_proxy_client()
 
     @swag_from('swagger_doc/user/read_get.yml')
-    def get(self, user_id: str) -> Iterable[Union[Mapping, int, None]]:
+    def get(self, id: str) -> Iterable[Union[Mapping, int, None]]:
         """
         Return a list of resources that user has read
 
-        :param user_id:
+        :param id:
         :return:
         """
         try:
-            resources = self.client.get_frequently_used_tables(user_email=user_id)
+            resources = self.client.get_frequently_used_tables(user_email=id)
             return marshal(resources, table_list_fields), HTTPStatus.OK
 
         except NotFoundException:
-            return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND
+            return {'message': f'user_id {id} does not exist'}, HTTPStatus.NOT_FOUND
 
         except Exception:
             LOGGER.exception('UserReadsAPI GET Failed')

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -282,7 +282,7 @@ class AtlasProxy(BaseProxy):
             )
         return sorted(columns, key=lambda item: item.sort_order)
 
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     def get_users(self) -> List[UserEntity]:

--- a/metadata_service/proxy/base_proxy.py
+++ b/metadata_service/proxy/base_proxy.py
@@ -14,7 +14,7 @@ class BaseProxy(metaclass=ABCMeta):
     the proxy clients available in the amundsen metadata service
     """
     @abstractmethod
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     @abstractmethod

--- a/metadata_service/proxy/gremlin_proxy.py
+++ b/metadata_service/proxy/gremlin_proxy.py
@@ -85,7 +85,7 @@ class AbstractGremlinProxy(BaseProxy):
         """  # noqa: E501
         return self.remote_connection._client.submit(message=command, bindings=bindings).all().result()
 
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         pass
 
     def get_users(self) -> List[UserEntity]:

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -710,7 +710,7 @@ class Neo4jProxy(BaseProxy):
         return popular_tables
 
     @timer_with_counter
-    def get_user(self, *, user_id: str) -> Union[UserEntity, None]:
+    def get_user(self, *, id: str) -> Union[UserEntity, None]:
         """
         Retrieve user detail based on user_id(email).
 
@@ -725,12 +725,12 @@ class Neo4jProxy(BaseProxy):
         """)
 
         record = self._execute_cypher_query(statement=query,
-                                            param_dict={'user_id': user_id})
+                                            param_dict={'user_id': id})
         single_result = record.single()
 
         if not single_result:
             raise NotFoundException('User {user_id} '
-                                    'not found in the graph'.format(user_id=user_id))
+                                    'not found in the graph'.format(user_id=id))
 
         record = single_result.get('user_record', {})
         manager_record = single_result.get('manager_record', {})

--- a/tests/unit/api/test_user.py
+++ b/tests/unit/api/test_user.py
@@ -6,6 +6,7 @@ from mock import MagicMock
 
 from metadata_service.api.user import (UserDetailAPI, UserFollowAPI, UserFollowsAPI,
                                        UserOwnsAPI, UserOwnAPI, UserReadsAPI)
+from metadata_service.util import UserResourceRel
 
 
 class UserDetailAPITest(unittest.TestCase):
@@ -26,7 +27,7 @@ class UserDetailAPITest(unittest.TestCase):
         self.mock_client.get_users.return_value = []
         response = self.api.get()
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.get_users.assert_called_once()
+        self.mock_client.get_users.assert_called_once_with()
 
 
 class UserFollowsAPITest(unittest.TestCase):
@@ -39,9 +40,10 @@ class UserFollowsAPITest(unittest.TestCase):
 
     def test_get(self) -> None:
         self.mock_client.get_table_by_user_relation.return_value = {'table': []}
-        response = self.api.get(user_id='username')
+        response = self.api.get(id='username')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.get_table_by_user_relation.assert_called_once()
+        self.mock_client.get_table_by_user_relation.assert_called_once_with(user_email='username',
+                                                                            relation_type=UserResourceRel.follow)
 
 
 class UserFollowAPITest(unittest.TestCase):
@@ -53,14 +55,18 @@ class UserFollowAPITest(unittest.TestCase):
         self.api = UserFollowAPI()
 
     def test_put(self) -> None:
-        response = self.api.put(user_id='username', resource_type='2', table_uri='3')
+        response = self.api.put(id='username', resource_type='2', table_uri='3')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.add_table_relation_by_user.assert_called_once()
+        self.mock_client.add_table_relation_by_user.assert_called_once_with(user_email='username',
+                                                                            table_uri='3',
+                                                                            relation_type=UserResourceRel.follow)
 
     def test_delete(self) -> None:
-        response = self.api.delete(user_id='username', resource_type='2', table_uri='3')
+        response = self.api.delete(id='username', resource_type='2', table_uri='3')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.delete_table_relation_by_user.assert_called_once()
+        self.mock_client.delete_table_relation_by_user.assert_called_once_with(user_email='username',
+                                                                               table_uri='3',
+                                                                               relation_type=UserResourceRel.follow)
 
 
 class UserOwnsAPITest(unittest.TestCase):
@@ -73,9 +79,10 @@ class UserOwnsAPITest(unittest.TestCase):
 
     def test_get(self) -> None:
         self.mock_client.get_table_by_user_relation.return_value = {'table': []}
-        response = self.api.get(user_id='username')
+        response = self.api.get(id='username')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.get_table_by_user_relation.assert_called_once()
+        self.mock_client.get_table_by_user_relation.assert_called_once_with(user_email='username',
+                                                                            relation_type=UserResourceRel.own)
 
 
 class UserOwnAPITest(unittest.TestCase):
@@ -87,14 +94,14 @@ class UserOwnAPITest(unittest.TestCase):
         self.api = UserOwnAPI()
 
     def test_put(self) -> None:
-        response = self.api.put(user_id='username', resource_type='2', table_uri='3')
+        response = self.api.put(id='username', resource_type='2', table_uri='3')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.add_owner.assert_called_once()
+        self.mock_client.add_owner.assert_called_once_with(owner='username', table_uri='3')
 
     def test_delete(self) -> None:
-        response = self.api.delete(user_id='username', resource_type='2', table_uri='3')
+        response = self.api.delete(id='username', resource_type='2', table_uri='3')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.delete_owner.assert_called_once()
+        self.mock_client.delete_owner.assert_called_once_with(owner='username', table_uri='3')
 
 
 class UserReadsAPITest(unittest.TestCase):
@@ -104,6 +111,6 @@ class UserReadsAPITest(unittest.TestCase):
         mock_get_proxy_client.return_value = mock_client
         mock_client.get_table_by_user_relation.return_value = {'table': []}
         api = UserReadsAPI()
-        response = api.get(user_id='username')
+        response = api.get(id='username')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        mock_client.get_frequently_used_tables.assert_called_once()
+        mock_client.get_frequently_used_tables.assert_called_once_with(user_email='username')

--- a/tests/unit/api/test_user.py
+++ b/tests/unit/api/test_user.py
@@ -20,7 +20,7 @@ class UserDetailAPITest(unittest.TestCase):
         self.mock_client.get_user.return_value = {}
         response = self.api.get(id='username')
         self.assertEqual(list(response)[1], HTTPStatus.OK)
-        self.mock_client.get_user.assert_called_once()
+        self.mock_client.get_user.assert_called_once_with(id='username')
 
     def test_gets(self) -> None:
         self.mock_client.get_users.return_value = []

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -511,7 +511,7 @@ class TestNeo4jProxy(unittest.TestCase):
                 }
             }
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            neo4j_user = neo4j_proxy.get_user(user_id='test_email')
+            neo4j_user = neo4j_proxy.get_user(id='test_email')
             self.assertEquals(neo4j_user.email, 'test_email')
 
     def test_get_users(self) -> None:
@@ -606,7 +606,7 @@ class TestNeo4jProxy(unittest.TestCase):
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             mock_execute.return_value.single.return_value = None
             neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
-            self.assertRaises(NotFoundException, neo4j_proxy.get_user, user_id='invalid_email')
+            self.assertRaises(NotFoundException, neo4j_proxy.get_user, id='invalid_email')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary of Changes

This PR is in response to comments about user_id / id not being used in the same way across user endpoints. I updated and improved upon existing tests. Because the routes are named and user id is passed through via these named routes, this change should not affect the front end. The endpoints can still be called in the same way (CC @feng-tao)

For example:
```
curl http://0.0.0.0:5002/user/harrypotter/own/
{"table": []}

curl http://0.0.0.0:5002/user/harrypotter/follow/
{"table": []}

curl http://0.0.0.0:5002/user/aransbury/read/
{"table": []}

curl http://0.0.0.0:5002/user/harrypotter
{"slack_id": null, "last_name": "Potter", "github_username": null, "email": "harrypotter@example.com", "first_name": "Harry", "team_name": null, "is_active": true, "full_name": "Harry Potter", "employee_type": null, "manager_fullname": ""}
```

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
