### PR TITLE
Reverting user follows API from using PopularTableSchema

### DIFF
--- a/metadata_service/api/user.py
+++ b/metadata_service/api/user.py
@@ -67,9 +67,7 @@ class UserFollowsAPI(Resource):
         try:
             resources = self.client.get_table_by_user_relation(user_email=user_id,
                                                                relation_type=UserResourceRel.follow)
-            if len(resources['table']) > 0:
-                return {'table': PopularTableSchema(many=True).dump(resources['table']).data}, HTTPStatus.OK
-            return {'table': []}, HTTPStatus.OK
+            return marshal(resources, table_list_fields), HTTPStatus.OK
 
         except NotFoundException:
             return {'message': 'user_id {} does not exist'.format(user_id)}, HTTPStatus.NOT_FOUND

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pytest-mock==1.1
 typing==3.6.4
 
 
-amundsen-common==0.1.7rc1
+amundsen-common==0.1.3rc0
 flasgger==0.9.3
 Flask-RESTful==0.3.6
 Flask==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ pytest-mock==1.1
 typing==3.6.4
 
 
-amundsen-common==0.1.3
+amundsen-common==0.1.7rc1
 flasgger==0.9.3
 Flask-RESTful==0.3.6
 Flask==1.0.2

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9rc0'
+__version__ = '1.1.9rc1'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9rc6'
+__version__ = '1.1.9'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9rc4'
+__version__ = '1.1.9rc5'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9rc5'
+__version__ = '1.1.9rc6'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '1.1.9rc1'
+__version__ = '1.1.9rc4'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
### Summary of Changes

Recent [PR](https://github.com/lyft/amundsenmetadatalibrary/pull/99) brought backward incompatible change to "user follows" API and this PR is to revert the change.

Also, uses amundsen-common==0.1.3rc0 for 0.1.3 is for Python>=3.7 and it is not compatible with other micro-services.

This is a short term fix to fix broken master branch. 

### Tests

Integration test done.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
