### PR TITLE
Add product and recent_view_count to Dashboard APIs

### DIFF
--- a/metadata_service/api/swagger_doc/template.yml
+++ b/metadata_service/api/swagger_doc/template.yml
@@ -314,7 +314,7 @@ components:
               $ref: '#/components/schemas/TagFields'
         recent_view_count:
           type: int
-          description: 'Dashboard recent view count'
+          description: 'Dashboard recent view count. Not using explicit duration, as it is up to timely ingestion and timely removal of stale data'
           example: 1024
     DashboardSummary:
       type: object

--- a/metadata_service/api/swagger_doc/template.yml
+++ b/metadata_service/api/swagger_doc/template.yml
@@ -255,6 +255,10 @@ components:
         group_url:
           type: string
           description: 'Dashboard group URL'
+        product:
+          type: string
+          description: 'Dashboard product name'
+          example: 'mode'
         name:
           type: string
           description: 'Dashboard name'
@@ -308,6 +312,10 @@ components:
             description: 'Badges associated with the Dashboard'
             items:
               $ref: '#/components/schemas/TagFields'
+        recent_view_count:
+          type: int
+          description: 'Dashboard recent view count'
+          example: 1024
     DashboardSummary:
       type: object
       properties:
@@ -323,6 +331,10 @@ components:
         group_url:
           type: string
           description: 'Dashboard group URL'
+        product:
+          type: string
+          description: 'Dashboard product name'
+          example: 'mode'
         name:
           type: string
           description: 'Dashboard name'

--- a/metadata_service/api/swagger_doc/user/follow_get.yml
+++ b/metadata_service/api/swagger_doc/user/follow_get.yml
@@ -22,6 +22,10 @@ responses:
               type: array
               items:
                 $ref: '#/components/schemas/PopularTables'
+            dashboard:
+              type: array
+              items:
+                $ref: '#/components/schemas/DashboardSummary'
   404:
     description: 'User not found'
     content:

--- a/metadata_service/entity/dashboard_detail.py
+++ b/metadata_service/entity/dashboard_detail.py
@@ -15,6 +15,7 @@ class DashboardDetail:
     cluster: str = attr.ib()
     group_name: str = attr.ib()
     group_url: str = attr.ib()
+    product: str = attr.ib()
     name: str = attr.ib()
     url: str = attr.ib()
     description: Optional[str] = attr.ib()
@@ -30,6 +31,7 @@ class DashboardDetail:
     tables: List[PopularTable] = attr.ib(factory=list)
     tags: List[Tag] = attr.ib(factory=list)
     badges: List[Tag] = attr.ib(factory=list)
+    recent_view_count: Optional[int] = attr.ib(default=0)
 
 
 class DashboardSchema(AttrsSchema):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.4.1'
+__version__ = '2.4.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -592,6 +592,7 @@ class TestNeo4jProxy(unittest.TestCase):
                     'cluster_name': 'cluster',
                     'dg_name': 'dashboard_group',
                     'dg_url': 'http://foo.bar/group',
+                    'product': 'foobar',
                     'name': 'dashboard',
                     'url': 'http://foo.bar/dashboard',
                     'description': 'description',
@@ -607,6 +608,7 @@ class TestNeo4jProxy(unittest.TestCase):
                                         cluster='cluster',
                                         group_name='dashboard_group',
                                         group_url='http://foo.bar/group',
+                                        product='foobar',
                                         name='dashboard',
                                         url='http://foo.bar/dashboard',
                                         description='description',
@@ -670,6 +672,7 @@ class TestNeo4jProxy(unittest.TestCase):
                     'cluster_name': 'cluster_name',
                     'uri': 'foo_dashboard://gold.bar/dashboard_id',
                     'url': 'http://www.foo.bar/dashboard_id',
+                    'product': 'foobar',
                     'name': 'dashboard name',
                     'created_timestamp': 123456789,
                     'description': 'description',
@@ -679,6 +682,7 @@ class TestNeo4jProxy(unittest.TestCase):
                     'last_run_timestamp': 987654321,
                     'last_run_state': 'good_state',
                     'updated_timestamp': 123456654321,
+                    'recent_view_count': 100,
                     'owners': [
                         {
                             'employee_type': 'teamMember',
@@ -720,6 +724,7 @@ class TestNeo4jProxy(unittest.TestCase):
                     'cluster_name': 'cluster_name',
                     'uri': 'foo_dashboard://gold.bar/dashboard_id',
                     'url': 'http://www.foo.bar/dashboard_id',
+                    'product': 'foobar',
                     'name': 'dashboard name',
                     'created_timestamp': 123456789,
                     'description': None,
@@ -728,6 +733,7 @@ class TestNeo4jProxy(unittest.TestCase):
                     'last_run_timestamp': None,
                     'last_run_state': None,
                     'updated_timestamp': None,
+                    'recent_view_count': 0,
                     'owners': [],
                     'tags': []
                 }
@@ -736,6 +742,7 @@ class TestNeo4jProxy(unittest.TestCase):
             dashboard = neo4j_proxy.get_dashboard(id='dashboard_id')
             expected = DashboardDetail(uri='foo_dashboard://gold.bar/dashboard_id', cluster='cluster_name',
                                        group_name='group_name', group_url='http://www.group_url.com',
+                                       product='foobar',
                                        name='dashboard name', url='http://www.foo.bar/dashboard_id',
                                        description='description', created_timestamp=123456789,
                                        last_successful_run_timestamp=9876543210,
@@ -755,17 +762,20 @@ class TestNeo4jProxy(unittest.TestCase):
                                                     employee_type='teamMember', manager_fullname='')],
                                        frequent_users=[], chart_names=[], query_names=[], tables=[],
                                        tags=[Tag(tag_type='tag_type1', tag_name='tag_key1'),
-                                             Tag(tag_type='tag_type2', tag_name='tag_key2')])
+                                             Tag(tag_type='tag_type2', tag_name='tag_key2')],
+                                       recent_view_count=100)
 
             self.assertEqual(expected, dashboard)
 
             dashboard2 = neo4j_proxy.get_dashboard(id='dashboard_id')
             expected2 = DashboardDetail(uri='foo_dashboard://gold.bar/dashboard_id', cluster='cluster_name',
                                         group_name='group_name', group_url='http://www.group_url.com',
-                                        name='dashboard name', url='http://www.foo.bar/dashboard_id', description=None,
+                                        product='foobar', name='dashboard name',
+                                        url='http://www.foo.bar/dashboard_id', description=None,
                                         created_timestamp=123456789, updated_timestamp=None, last_run_timestamp=None,
                                         last_run_state=None, owners=[], frequent_users=[], chart_names=[],
-                                        query_names=[], tables=[], tags=[], last_successful_run_timestamp=None)
+                                        query_names=[], tables=[], tags=[], last_successful_run_timestamp=None,
+                                        recent_view_count=0)
 
             self.assertEqual(expected2, dashboard2)
 


### PR DESCRIPTION
### Summary of Changes

Updated:
 - Added `product` and `recent_view_count` to Dashboard Detail GET API and Bookmarks GET API
 - Neo4j Cypher query to perform early aggregation for better performance.

### Tests

Updated unit tests. Performed integration tests.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
