### PR TITLE
Fix Bookmarks after latest changes (AtlasProxy)

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -111,6 +111,28 @@ class AtlasProxy(BaseProxy):
         result = pattern.match(table_uri)
         return result.groupdict() if result else dict()
 
+    def _parse_reader_qn(self, reader_qn: str) -> Dict:
+        """
+        Parse reader qualifiedName and extract the info
+        :param reader_qn:
+        :return: Dictionary object containing following information:
+        cluster: cluster information
+        db: Database name
+        name: Table name
+        """
+        pattern = re.compile(r"""
+        ^(?P<db>[^.]*)
+        \.
+        (?P<table>[^.]*)
+        \.
+        (?P<user_id>[^.]*)\.reader
+        \@
+        (?P<cluster>.*)
+        $
+        """, re.X)
+        result = pattern.match(reader_qn)
+        return result.groupdict() if result else dict()
+
     def _parse_bookmark_qn(self, bookmark_qn: str) -> Dict:
         """
         Parse bookmark qualifiedName and extract the info
@@ -201,10 +223,7 @@ class AtlasProxy(BaseProxy):
         """
         user_entity = self._driver.entity_unique_attribute(self.USER_TYPE, qualifiedName=user_id)
 
-        if not user_entity.entity:
-            return False
-        else:
-            return True
+        return bool(user_entity.entity)
 
     def create_user(self, user_id: str) -> None:
         """

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -42,7 +42,7 @@ class AtlasProxy(BaseProxy):
     BOOKMARK_TYPE = 'Bookmark'
     USER_TYPE = 'User'
     QN_KEY = 'qualifiedName'
-    BOOMARK_ACTIVE_KEY = 'active'
+    BOOKMARK_ACTIVE_KEY = 'active'
     GUID_KEY = 'guid'
     ATTRS_KEY = 'attributes'
     REL_ATTRS_KEY = 'relationshipAttributes'
@@ -184,7 +184,7 @@ class AtlasProxy(BaseProxy):
             'entity': {
                 'typeName': self.BOOKMARK_TYPE,
                 'attributes': {'qualifiedName': bookmark_qn,
-                               self.BOOMARK_ACTIVE_KEY: True,
+                               self.BOOKMARK_ACTIVE_KEY: True,
                                'entityUri': table_uri,
                                'user': {'guid': user_guid},
                                'entity': {'guid': entity.entity[self.GUID_KEY]}}
@@ -569,7 +569,7 @@ class AtlasProxy(BaseProxy):
                         'attributeValue': f'.{user_email}.bookmark'
                     },
                     {
-                        'attributeName': self.BOOMARK_ACTIVE_KEY,
+                        'attributeName': self.BOOKMARK_ACTIVE_KEY,
                         'operator': 'eq',
                         'attributeValue': 'true'
                     }
@@ -614,7 +614,7 @@ class AtlasProxy(BaseProxy):
                                     relation_type: UserResourceRel) -> None:
 
         entity = self._get_bookmark_entity(entity_uri=table_uri, user_id=user_email)
-        entity.entity[self.ATTRS_KEY][self.BOOMARK_ACTIVE_KEY] = True
+        entity.entity[self.ATTRS_KEY][self.BOOKMARK_ACTIVE_KEY] = True
         entity.update()
 
     def delete_resource_relation_by_user(self, *,
@@ -634,7 +634,7 @@ class AtlasProxy(BaseProxy):
                                        user_email: str,
                                        relation_type: UserResourceRel) -> None:
         entity = self._get_bookmark_entity(entity_uri=table_uri, user_id=user_email)
-        entity.entity[self.ATTRS_KEY][self.BOOMARK_ACTIVE_KEY] = False
+        entity.entity[self.ATTRS_KEY][self.BOOKMARK_ACTIVE_KEY] = False
         entity.update()
 
     def get_dashboard(self,

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -215,34 +215,6 @@ class AtlasProxy(BaseProxy):
 
         self._driver.entity_post.create(data=bookmark_entity)
 
-    def user_exists(self, user_id: str) -> bool:
-        """
-        Verifies if given user exists in Atlas.
-        :param user_id: User's id
-        :return: True if user exists, otherwise False
-        """
-        user_entity = self._driver.entity_unique_attribute(self.USER_TYPE, qualifiedName=user_id)
-
-        return bool(user_entity.entity)
-
-    def create_user(self, user_id: str) -> None:
-        """
-        Creates a User entity.
-        :param user_id: User's id
-        :return:
-        """
-        user_entity = {
-            'entity': {
-                'typeName': self.USER_TYPE,
-                'attributes': {'qualifiedName': user_id}
-            }
-        }
-
-        try:
-            self._driver.entity_post.create(data=user_entity)
-        except Exception as ex:
-            LOGGER.error('Error creating user.', exc_info=True)
-
     def _get_bookmark_entity(self, entity_uri: str, user_id: str) -> EntityUniqueAttribute:
         """
         Fetch a Bookmark entity from parsing table uri and user id.

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -39,9 +39,10 @@ class AtlasProxy(BaseProxy):
     TABLE_ENTITY = app.config['ATLAS_TABLE_ENTITY']
     DB_ATTRIBUTE = app.config['ATLAS_DB_ATTRIBUTE']
     STATISTICS_FORMAT_SPEC = app.config['STATISTICS_FORMAT_SPEC']
-    READER_TYPE = 'Reader'
+    BOOKMARK_TYPE = 'Bookmark'
+    USER_TYPE = 'User'
     QN_KEY = 'qualifiedName'
-    BKMARKS_KEY = 'isFollowing'
+    BOOMARK_ACTIVE_KEY = 'active'
     GUID_KEY = 'guid'
     ATTRS_KEY = 'attributes'
     REL_ATTRS_KEY = 'relationshipAttributes'
@@ -110,10 +111,10 @@ class AtlasProxy(BaseProxy):
         result = pattern.match(table_uri)
         return result.groupdict() if result else dict()
 
-    def _parse_reader_qn(self, reader_qn: str) -> Dict:
+    def _parse_bookmark_qn(self, bookmark_qn: str) -> Dict:
         """
-        Parse reader qualifiedName and extract the info
-        :param reader_qn:
+        Parse bookmark qualifiedName and extract the info
+        :param bookmark_qn: Qualified Name of Bookmark entity
         :return: Dictionary object containing following information:
         cluster: cluster information
         db: Database name
@@ -124,12 +125,14 @@ class AtlasProxy(BaseProxy):
         \.
         (?P<table>[^.]*)
         \.
-        (?P<user_id>[^.]*)\.reader
+        (?P<entity_type>[^.]*)
+        \.
+        (?P<user_id>[^.]*)\.bookmark
         \@
         (?P<cluster>.*)
         $
         """, re.X)
-        result = pattern.match(reader_qn)
+        result = pattern.match(bookmark_qn)
         return result.groupdict() if result else dict()
 
     def _get_table_entity(self, *, table_uri: str) -> EntityUniqueAttribute:
@@ -168,57 +171,93 @@ class AtlasProxy(BaseProxy):
             raise NotFoundException('(User {user_id}) does not exist'
                                     .format(user_id=user_id))
 
-    def _create_reader(self, table_entity: EntityUniqueAttribute, user_guid: str, reader_qn: str) -> None:
+    def _create_bookmark(self, entity: EntityUniqueAttribute, user_guid: str, bookmark_qn: str,
+                         table_uri: str) -> None:
         """
-        Creates a reader entity for a specific user and table uri.
+        Creates a bookmark entity for a specific user and table uri.
         :param user_guid: User's guid
-        :param reader_qn: Reader qualifiedName
+        :param bookmark_qn: Bookmark qualifiedName
         :return:
         """
-        reader_entity = {
-            'typeName': self.READER_TYPE,
-            'attributes': {'qualifiedName': reader_qn,
-                           'isFollowing': True,
-                           'count': 0,
-                           'user': {'guid': user_guid}}
+
+        bookmark_entity = {
+            'entity': {
+                'typeName': self.BOOKMARK_TYPE,
+                'attributes': {'qualifiedName': bookmark_qn,
+                               self.BOOMARK_ACTIVE_KEY: True,
+                               'entityUri': table_uri,
+                               'user': {'guid': user_guid},
+                               'entity': {'guid': entity.entity[self.GUID_KEY]}}
+            }
         }
 
-        self._driver.entity_post.create(data=reader_entity)
-        table_entity.entity[self.ATTRS_KEY]['readers'].append(reader_entity)
-        table_entity.update()
+        self._driver.entity_post.create(data=bookmark_entity)
 
-    def _get_reader_entity(self, table_uri: str, user_id: str) -> EntityUniqueAttribute:
+    def user_exists(self, user_id: str) -> bool:
         """
-        Fetch a Reader entity from parsing table uri and user id.
-        If Reader is not present, create one for the user.
+        Verifies if given user exists in Atlas.
+        :param user_id: User's id
+        :return: True if user exists, otherwise False
+        """
+        user_entity = self._driver.entity_unique_attribute(self.USER_TYPE, qualifiedName=user_id)
+
+        if not user_entity.entity:
+            return False
+        else:
+            return True
+
+    def create_user(self, user_id: str) -> None:
+        """
+        Creates a User entity.
+        :param user_id: User's id
+        :return:
+        """
+        user_entity = {
+            'entity': {
+                'typeName': self.USER_TYPE,
+                'attributes': {'qualifiedName': user_id}
+            }
+        }
+
+        try:
+            self._driver.entity_post.create(data=user_entity)
+        except Exception as ex:
+            LOGGER.error('Error creating user.', exc_info=True)
+
+    def _get_bookmark_entity(self, entity_uri: str, user_id: str) -> EntityUniqueAttribute:
+        """
+        Fetch a Bookmark entity from parsing table uri and user id.
+        If Bookmark is not present, create one for the user.
         :param table_uri:
         :param user_id: Qualified Name of a user
         :return:
         """
-        table_info = self._extract_info_from_uri(table_uri=table_uri)
-        reader_qn = '{}.{}.{}.reader@{}'.format(table_info.get('db'),
-                                                table_info.get('name'),
-                                                user_id,
-                                                table_info.get('cluster'))
+        table_info = self._extract_info_from_uri(table_uri=entity_uri)
+        bookmark_qn = '{}.{}.{}.{}.bookmark@{}'.format(table_info.get('db'),
+                                                       table_info.get('name'),
+                                                       table_info.get('entity'),
+                                                       user_id,
+                                                       table_info.get('cluster'))
 
         try:
-            reader_entity = self._driver.entity_unique_attribute(
-                self.READER_TYPE, qualifiedName=reader_qn)
-            if not reader_entity.entity:
-                table_entity = self._get_table_entity(table_uri=table_uri)
+            bookmark_entity = self._driver.entity_unique_attribute(self.BOOKMARK_TYPE, qualifiedName=bookmark_qn)
+
+            if not bookmark_entity.entity:
+                table_entity = self._get_table_entity(table_uri=entity_uri)
                 # Fetch user entity from user_id for relation
                 user_entity = self._get_user_entity(user_id)
-                # Create reader entity with the user relation.
-                self._create_reader(table_entity.entity[self.ATTRS_KEY][self.GUID_KEY],
-                                    user_entity.entity[self.GUID_KEY], reader_qn)
-                # Fetch reader entity after creating it.
-                reader_entity = self._driver.entity_unique_attribute(self.READER_TYPE, qualifiedName=reader_qn)
-            return reader_entity
+                # Create bookmark entity with the user relation.
+                self._create_bookmark(table_entity,
+                                      user_entity.entity[self.GUID_KEY], bookmark_qn, entity_uri)
+                # Fetch bookmark entity after creating it.
+                bookmark_entity = self._driver.entity_unique_attribute(self.BOOKMARK_TYPE, qualifiedName=bookmark_qn)
+
+            return bookmark_entity
 
         except Exception as ex:
-            LOGGER.exception(f'Reader not found. {str(ex)}')
-            raise NotFoundException('Reader( {reader_qn} ) does not exist'
-                                    .format(reader_qn=reader_qn))
+            LOGGER.exception(f'Bookmark not found. {str(ex)}')
+            raise NotFoundException('Bookmark( {bookmark_qn} ) does not exist'
+                                    .format(bookmark_qn=bookmark_qn))
 
     def _get_column(self, *, table_uri: str, column_name: str) -> Dict:
         """
@@ -231,7 +270,7 @@ class AtlasProxy(BaseProxy):
             table_entity = self._get_table_entity(table_uri=table_uri)
             columns = table_entity.entity[self.REL_ATTRS_KEY].get('columns')
             for column in columns or list():
-                col_details = table_entity.referredEntities[column['guid']]
+                col_details = table_entity.referredEntities[column[self.GUID_KEY]]
                 if column_name == col_details[self.ATTRS_KEY]['name']:
                     return col_details
 
@@ -253,7 +292,7 @@ class AtlasProxy(BaseProxy):
         """
         columns = list()
         for column in entity.entity[self.REL_ATTRS_KEY].get('columns') or list():
-            col_entity = entity.referredEntities[column['guid']]
+            col_entity = entity.referredEntities[column[self.GUID_KEY]]
             col_attrs = col_entity[self.ATTRS_KEY]
             statistics = list()
 
@@ -403,7 +442,7 @@ class AtlasProxy(BaseProxy):
         """
         entity = self._get_table_entity(table_uri=id)
         entity_bulk_tag = {"classification": {"typeName": tag},
-                           "entityGuids": [entity.entity['guid']]}
+                           "entityGuids": [entity.entity[self.GUID_KEY]]}
         self._driver.entity_bulk_classification.create(data=entity_bulk_tag)
 
     def delete_tag(self, *, id: str, tag: str, tag_type: str,
@@ -417,7 +456,7 @@ class AtlasProxy(BaseProxy):
         """
         try:
             entity = self._get_table_entity(table_uri=id)
-            guid_entity = self._driver.entity_guid(entity.entity['guid'])
+            guid_entity = self._driver.entity_guid(entity.entity[self.GUID_KEY])
             guid_entity.classifications(tag).delete()
         except Exception as ex:
             # FixMe (Verdan): Too broad exception. Please make it specific
@@ -437,7 +476,7 @@ class AtlasProxy(BaseProxy):
         column_detail = self._get_column(
             table_uri=table_uri,
             column_name=column_name)
-        col_guid = column_detail['guid']
+        col_guid = column_detail[self.GUID_KEY]
 
         entity = self._driver.entity_guid(col_guid)
         entity.entity[self.ATTRS_KEY]['description'] = description
@@ -517,19 +556,20 @@ class AtlasProxy(BaseProxy):
 
     def get_table_by_user_relation(self, *, user_email: str, relation_type: UserResourceRel) -> Dict[str, Any]:
         params = {
-            'typeName': self.READER_TYPE,
+            'typeName': self.BOOKMARK_TYPE,
             'offset': '0',
             'limit': '1000',
+            'excludeDeletedEntities': True,
             'entityFilters': {
                 'condition': 'AND',
                 'criterion': [
                     {
                         'attributeName': self.QN_KEY,
                         'operator': 'contains',
-                        'attributeValue': user_email
+                        'attributeValue': f'.{user_email}.bookmark'
                     },
                     {
-                        'attributeName': self.BKMARKS_KEY,
+                        'attributeName': self.BOOMARK_ACTIVE_KEY,
                         'operator': 'eq',
                         'attributeValue': 'true'
                     }
@@ -537,13 +577,13 @@ class AtlasProxy(BaseProxy):
             },
             'attributes': ['count', self.QN_KEY, self.ENTITY_URI_KEY]
         }
-        # Fetches the reader entities based on filters
+        # Fetches the bookmark entities based on filters
         search_results = self._driver.search_basic.create(data=params)
 
         results = []
         for record in search_results.entities:
             table_info = self._extract_info_from_uri(table_uri=record.attributes[self.ENTITY_URI_KEY])
-            res = self._parse_reader_qn(record.attributes[self.QN_KEY])
+            res = self._parse_bookmark_qn(record.attributes[self.QN_KEY])
             results.append(PopularTable(
                 database=table_info['entity'],
                 cluster=res['cluster'],
@@ -573,8 +613,8 @@ class AtlasProxy(BaseProxy):
                                     user_email: str,
                                     relation_type: UserResourceRel) -> None:
 
-        entity = self._get_reader_entity(table_uri=table_uri, user_id=user_email)
-        entity.entity[self.ATTRS_KEY][self.BKMARKS_KEY] = True
+        entity = self._get_bookmark_entity(entity_uri=table_uri, user_id=user_email)
+        entity.entity[self.ATTRS_KEY][self.BOOMARK_ACTIVE_KEY] = True
         entity.update()
 
     def delete_resource_relation_by_user(self, *,
@@ -593,8 +633,8 @@ class AtlasProxy(BaseProxy):
                                        table_uri: str,
                                        user_email: str,
                                        relation_type: UserResourceRel) -> None:
-        entity = self._get_reader_entity(table_uri=table_uri, user_id=user_email)
-        entity.entity[self.ATTRS_KEY][self.BKMARKS_KEY] = False
+        entity = self._get_bookmark_entity(entity_uri=table_uri, user_id=user_email)
+        entity.entity[self.ATTRS_KEY][self.BOOMARK_ACTIVE_KEY] = False
         entity.update()
 
     def get_dashboard(self,

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -120,40 +120,40 @@ class Data:
             entity2,
         ]
     }
-    reader_entity1 = {
-        "typeName": "Reader",
+
+    bookmark_entity1 = {
+        "typeName": "Bookmark",
         "attributes": {
-            "isFollowing": True,
-            "qualifiedName": '{}.{}.{}.reader@{}'.format(db, name, 'test_user_id', cluster),
-            "count": 96,
+            "active": True,
+            "qualifiedName": '{}.{}.{}.{}.bookmark@{}'.format(db, name, 'hive_table', 'test_user_id', cluster),
             "entityUri": table_uri,
         },
         "guid": "0fa40fd5-016c-472e-a72f-25a5013cc818",
         "status": "ACTIVE",
-        "displayText": '{}.{}.{}.reader@{}'.format(db, name, 'test_user_id', cluster),
+        "displayText": '{}.{}.{}.{}.bookmark@{}'.format(db, name, 'hive_table', 'test_user_id', cluster),
         "classificationNames": [],
         "meaningNames": [],
         "meanings": []
     }
 
-    reader_entity2 = {
-        "typeName": "Reader",
+    bookmark_entity2 = {
+        "typeName": "Bookmark",
         "attributes": {
-            "isFollowing": True,
-            "qualifiedName": '{}.{}.{}.reader@{}'.format(db, 'Table2', 'test_user_id', cluster),
-            "count": 96
+            "active": True,
+            "qualifiedName": '{}.{}.{}.{}.bookmark@{}'.format(db, 'Table2', 'hive_table', 'test_user_id', cluster),
+            "entityUri": table_uri,
         },
         "guid": "0fa40fd5-016c-472e-a72f-a72ffa40fd5",
         "status": "ACTIVE",
-        "displayText": '{}.{}.{}.reader@{}'.format(db, 'Table2', 'test_user_id', cluster),
+        "displayText": '{}.{}.{}.{}.bookmark@{}'.format(db, 'Table2', 'hive_table', 'test_user_id', cluster),
         "classificationNames": [],
         "meaningNames": [],
         "meanings": []
     }
 
-    reader_entities = {
+    bookmark_entities = {
         'entities': [
-            reader_entity1,
-            reader_entity2,
+            bookmark_entity1,
+            bookmark_entity2,
         ]
     }

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -48,11 +48,11 @@ class TestAtlasProxy(unittest.TestCase, Data):
         self.proxy._get_table_entity = MagicMock(return_value=mocked_entity)  # type: ignore
         return mocked_entity
 
-    def _mock_get_reader_entity(self, entity: Optional[Any] = None) -> Any:
+    def _mock_get_bookmark_entity(self, entity: Optional[Any] = None) -> Any:
         entity = entity or self.entity1
         mocked_entity = MagicMock()
         mocked_entity.entity = entity
-        self.proxy._get_reader_entity = MagicMock(return_value=mocked_entity)  # type: ignore
+        self.proxy._get_bookmark_entity = MagicMock(return_value=mocked_entity)  # type: ignore
         return mocked_entity
 
     def test_extract_table_uri_info(self) -> None:
@@ -271,12 +271,12 @@ class TestAtlasProxy(unittest.TestCase, Data):
                                           description='DOESNT_MATTER')
 
     def test_get_table_by_user_relation(self) -> None:
-        reader1 = copy.deepcopy(self.reader_entity1)
-        reader1 = self.to_class(reader1)
-        reader_collection = MagicMock()
-        reader_collection.entities = [reader1]
+        bookmark1 = copy.deepcopy(self.bookmark_entity1)
+        bookmark1 = self.to_class(bookmark1)
+        bookmark_collection = MagicMock()
+        bookmark_collection.entities = [bookmark1]
 
-        self.proxy._driver.search_basic.create = MagicMock(return_value=reader_collection)
+        self.proxy._driver.search_basic.create = MagicMock(return_value=bookmark_collection)
         res = self.proxy.get_table_by_user_relation(user_email='test_user_id',
                                                     relation_type=UserResourceRel.follow)
 
@@ -286,8 +286,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
         self.assertEqual(res, {'table': expected})
 
     def test_add_resource_relation_by_user(self) -> None:
-        reader_entity = self._mock_get_reader_entity()
-        with patch.object(reader_entity, 'update') as mock_execute:
+        bookmark_entity = self._mock_get_bookmark_entity()
+        with patch.object(bookmark_entity, 'update') as mock_execute:
             self.proxy.add_resource_relation_by_user(id=self.table_uri,
                                                      user_id="test_user_id",
                                                      relation_type=UserResourceRel.follow,
@@ -295,8 +295,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
             mock_execute.assert_called_with()
 
     def test_delete_resource_relation_by_user(self) -> None:
-        reader_entity = self._mock_get_reader_entity()
-        with patch.object(reader_entity, 'update') as mock_execute:
+        bookmark_entity = self._mock_get_bookmark_entity()
+        with patch.object(bookmark_entity, 'update') as mock_execute:
             self.proxy.delete_resource_relation_by_user(id=self.table_uri,
                                                         user_id="test_user_id",
                                                         relation_type=UserResourceRel.follow,


### PR DESCRIPTION
### Summary of Changes

With this PR:

- Bookmarks feature has been brought back to life
- Issue with retrieving other users bookmarks was fixed - when user A bookmarked user's B table, user B could also see it in his `My Bookmarks` section (assuming that db name is users id)
- Retrieval of deleted Bookmarks has been turned off
- New methods are added (create_user, user_exists) that can be used to add users to atlas automatically

Please note that it requires amundsenatlastypes in **1.1.0** version, where `Bookmark` entity was introduced.

### Tests

Aligned tests to new entity definitions.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
