### PR TITLE
Fix timestamp format of latest edit field [AtlasProxy]

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from random import randint
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Union, Optional
 
 from amundsen_common.models.popular_table import PopularTable
 from amundsen_common.models.table import Column, Statistics, Table, Tag, User
@@ -378,7 +378,7 @@ class AtlasProxy(BaseProxy):
                 description=attrs.get('description') or attrs.get('comment'),
                 owners=[User(email=attrs.get('owner'))],
                 columns=columns,
-                last_updated_timestamp=table_details.get('updateTime'))
+                last_updated_timestamp=self._parse_date(table_details.get('updateTime')))
 
             return table
         except KeyError as ex:
@@ -632,6 +632,17 @@ class AtlasProxy(BaseProxy):
         entity = self._get_bookmark_entity(entity_uri=table_uri, user_id=user_email)
         entity.entity[self.ATTRS_KEY][self.BOOKMARK_ACTIVE_KEY] = False
         entity.update()
+
+    def _parse_date(self, date: int) -> Optional[int]:
+        try:
+            date_str = str(date)
+            date_trimmed = date_str[:10]
+
+            assert len(date_trimmed) == 10
+
+            return int(date_trimmed)
+        except Exception:
+            return None
 
     def get_dashboard(self,
                       dashboard_uri: str,

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -74,7 +74,7 @@ class Data:
 
     db_entity = {
         'guid': '-100',
-        'updateTime': 234,
+        'updateTime': 2345678901234,
         'typeName': entity_type,
         'attributes': {
             'qualifiedName': db,
@@ -87,7 +87,7 @@ class Data:
     entity1 = {
         'guid': '1',
         'typeName': entity_type,
-        'updateTime': 123,
+        'updateTime': 1234567890123,
         'attributes': {
             'qualifiedName': '{}.{}@{}'.format(db, 'Table1', cluster),
             'name': 'Table1',

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -125,8 +125,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
                          tags=[Tag(tag_name=classif_name, tag_type="default")],
                          description=ent_attrs['description'],
                          owners=[User(email=ent_attrs['owner'])],
-                         columns=[exp_col] * self.active_columns,
-                         last_updated_timestamp=cast(int, self.entity1['updateTime']))
+                         last_updated_timestamp=int(str(self.entity1['updateTime'])[:10]),
+                         columns=[exp_col] * self.active_columns)
 
         self.assertEqual(str(expected), str(response))
 


### PR DESCRIPTION
### Summary of Changes

Atlas is returning timestamp in milliseconds, however Amundsen relies on Unix Epoch. This causes a bug in rendering the date in Table View UI.

### Tests

Aligned & run to successful completion.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
