### PR TITLE
feat: Add mode_user_id into User detail API

### DIFF
--- a/metadata_service/api/swagger_doc/template.yml
+++ b/metadata_service/api/swagger_doc/template.yml
@@ -100,6 +100,11 @@ components:
         manager_fullname:
           type: string
           description: 'User manager full name'
+        other_key_values:
+          type: object
+          additionalProperties:
+            type: string
+            description: 'Additional key value properties'
     ColumnFields:
       type: object
       properties:

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -1,6 +1,6 @@
 import distutils.util
 import os
-from typing import List, Dict, Optional  # noqa: F401
+from typing import List, Dict, Optional, Set  # noqa: F401
 
 # PROXY configuration keys
 PROXY_HOST = 'PROXY_HOST'
@@ -17,6 +17,7 @@ PROXY_CLIENTS = {
 }
 
 IS_STATSD_ON = 'IS_STATSD_ON'
+USER_OTHER_KEYS = 'USER_OTHER_KEYS'
 
 
 class Config:
@@ -56,9 +57,12 @@ class Config:
 
     USER_DETAIL_METHOD = None   # type: Optional[function]
 
+    # On User detail method, these keys will be added into amundsen_common.models.user.User.other_key_values
+    USER_OTHER_KEYS = {'mode_user_id'}  # type: Set[str]
+
 
 class LocalConfig(Config):
-    DEBUG = False
+    DEBUG = True
     TESTING = False
     LOG_LEVEL = 'DEBUG'
     LOCAL_HOST = '0.0.0.0'

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -820,6 +820,13 @@ class Neo4jProxy(BaseProxy):
 
     @staticmethod
     def _build_user_from_record(record: dict, manager_name: str = '') -> UserEntity:
+        """
+        Builds user record from Cypher query result. Other than the one defined in amundsen_common.models.user.User,
+        you could add more fields from User node into the User model by specifying keys in config.USER_OTHER_KEYS
+        :param record:
+        :param manager_name:
+        :return:
+        """
         other_key_values = {}
         if has_app_context() and current_app.config[config.USER_OTHER_KEYS]:
             for k in current_app.config[config.USER_OTHER_KEYS]:

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -5,6 +5,7 @@ from random import randint
 from typing import (Any, Dict, List, Optional, Tuple, Union,  # noqa: F401
                     no_type_check)
 
+import neo4j
 from amundsen_common.models.dashboard import DashboardSummary
 from amundsen_common.models.popular_table import PopularTable
 from amundsen_common.models.table import (Application, Column, Reader, Source,
@@ -14,9 +15,10 @@ from amundsen_common.models.table import Tag
 from amundsen_common.models.user import User as UserEntity
 from beaker.cache import CacheManager
 from beaker.util import parse_cache_config_options
+from flask import current_app, has_app_context
 from neo4j import BoltStatementResult, Driver, GraphDatabase  # noqa: F401
-import neo4j
 
+from metadata_service import config
 from metadata_service.entity.dashboard_detail import DashboardDetail as DashboardDetailEntity
 from metadata_service.entity.dashboard_query import DashboardQuery as DashboardQueryEntity
 from metadata_service.entity.description import Description
@@ -60,6 +62,7 @@ class Neo4jProxy(BaseProxy):
         value needs to be smaller than surrounding network environment's timeout.
         """
         endpoint = f'{host}:{port}'
+        LOGGER.info('NEO4J endpoint: {}'.format(endpoint))
         trust = neo4j.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES if validate_ssl else neo4j.TRUST_ALL_CERTIFICATES
         self._driver = GraphDatabase.driver(endpoint, max_connection_pool_size=num_conns,
                                             connection_timeout=10,
@@ -817,6 +820,12 @@ class Neo4jProxy(BaseProxy):
 
     @staticmethod
     def _build_user_from_record(record: dict, manager_name: str = '') -> UserEntity:
+        other_key_values = {}
+        if has_app_context() and current_app.config[config.USER_OTHER_KEYS]:
+            for k in current_app.config[config.USER_OTHER_KEYS]:
+                if k in record:
+                    other_key_values[k] = record[k]
+
         return UserEntity(email=record['email'],
                           first_name=record.get('first_name'),
                           last_name=record.get('last_name'),
@@ -827,7 +836,8 @@ class Neo4jProxy(BaseProxy):
                           slack_id=record.get('slack_id'),
                           employee_type=record.get('employee_type'),
                           role_name=record.get('role_name'),
-                          manager_fullname=record.get('manager_fullname', manager_name))
+                          manager_fullname=record.get('manager_fullname', manager_name),
+                          other_key_values=other_key_values)
 
     @staticmethod
     def _get_user_resource_relationship_clause(relation_type: UserResourceRel, id: str = None,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.5.1'
+__version__ = '2.5.2'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -562,7 +562,6 @@ class TestNeo4jProxy(unittest.TestCase):
             neo4j_user = neo4j_proxy.get_user(id='test_email')
             self.assertEquals(neo4j_user.other_key_values, {'mode_user_id': 'mode_foo_bar'})
 
-
     def test_get_users(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             test_user = {

--- a/tests/unit/proxy/test_neo4j_proxy.py
+++ b/tests/unit/proxy/test_neo4j_proxy.py
@@ -538,6 +538,31 @@ class TestNeo4jProxy(unittest.TestCase):
             neo4j_user = neo4j_proxy.get_user(id='test_email')
             self.assertEquals(neo4j_user.email, 'test_email')
 
+    def test_get_user_other_key_values(self) -> None:
+        with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
+            mock_execute.return_value.single.return_value = {
+                'user_record': {
+                    'employee_type': 'teamMember',
+                    'full_name': 'test_full_name',
+                    'is_active': 'True',
+                    'github_username': 'test-github',
+                    'slack_id': 'test_id',
+                    'last_name': 'test_last_name',
+                    'first_name': 'test_first_name',
+                    'team_name': 'test_team',
+                    'email': 'test_email',
+                    'mode_user_id': 'mode_foo_bar',
+                    'etc': 'etc_foo_bar',
+                },
+                'manager_record': {
+                    'full_name': 'test_manager_fullname'
+                }
+            }
+            neo4j_proxy = Neo4jProxy(host='DOES_NOT_MATTER', port=0000)
+            neo4j_user = neo4j_proxy.get_user(id='test_email')
+            self.assertEquals(neo4j_user.other_key_values, {'mode_user_id': 'mode_foo_bar'})
+
+
     def test_get_users(self) -> None:
         with patch.object(GraphDatabase, 'driver'), patch.object(Neo4jProxy, '_execute_cypher_query') as mock_execute:
             test_user = {


### PR DESCRIPTION
### Summary of Changes

Add `mode_user_id` into User detail API.

- Supports `other_key_values` in User detail API so that any other attributes in User node can configured to put into the API response.


Example:
```
User registered with Mode

{
    "email": "john@foo.com",
    "employee_type": "teamMember",
    "is_active": true,
    ...
    "other_key_values": {
        "mode_user_id": "foo_bar"
    },
    ...
}

User not registered with Mode
{
    "email": "john2@foo.com",
    "employee_type": "teamMember",
    "is_active": true,
    ...
    "other_key_values": {},
    ...
}
```

### Tests

Updated unit test. Performed integration test.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
