### PR TITLE
fix: PROXY_ENCRYPTED = False by default on Neo4j proxy

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -33,7 +33,7 @@ class Config:
 
     PROXY_USER = os.environ.get('CREDENTIALS_PROXY_USER', 'neo4j')
     PROXY_PASSWORD = os.environ.get('CREDENTIALS_PROXY_PASSWORD', 'test')
-    PROXY_ENCRYPTED = True
+    PROXY_ENCRYPTED = False
     """Whether the connection to the proxy should use SSL/TLS encryption."""
     PROXY_VALIDATE_SSL = True
     """Whether the SSL/TLS certificate presented by the user should be validated against the system's trusted CAs."""
@@ -70,7 +70,7 @@ class LocalConfig(Config):
     PROXY_HOST = os.environ.get('PROXY_HOST', f'bolt://{LOCAL_HOST}')
     PROXY_PORT = os.environ.get('PROXY_PORT', 7687)
     PROXY_CLIENT = PROXY_CLIENTS[os.environ.get('PROXY_CLIENT', 'NEO4J')]
-    PROXY_ENCRYPTED = bool(distutils.util.strtobool(os.environ.get(PROXY_ENCRYPTED, 'True')))
+    PROXY_ENCRYPTED = bool(distutils.util.strtobool(os.environ.get(PROXY_ENCRYPTED, 'False')))
     PROXY_VALIDATE_SSL = bool(distutils.util.strtobool(os.environ.get(PROXY_VALIDATE_SSL, 'False')))
 
     JANUS_GRAPH_URL = None

--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -49,7 +49,7 @@ class Neo4jProxy(BaseProxy):
                  password: str = '',
                  num_conns: int = 50,
                  max_connection_lifetime_sec: int = 100,
-                 encrypted: bool = True,
+                 encrypted: bool = False,
                  validate_ssl: bool = False) -> None:
         """
         There's currently no request timeout from client side where server

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.5.2'
+__version__ = '2.5.3'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
### Summary of Changes

New [update](https://github.com/lyft/amundsenmetadatalibrary/pull/139) on Neo4j proxy fails on the service that has no proper setup on certificate.

This PR is to disable SSL by default to keep backward compatibility.

`neobolt.exceptions.SecurityError: Failed to establish secure connection to '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:748)'"
`
### Tests

Integration test.

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
