### PR TITLE
fix: Remove tx.close() with Neo4j driver upgrade

### DIFF
--- a/metadata_service/proxy/neo4j_proxy.py
+++ b/metadata_service/proxy/neo4j_proxy.py
@@ -390,7 +390,6 @@ class Neo4jProxy(BaseProxy):
             raise e
 
         finally:
-            tx.close()
             if LOGGER.isEnabledFor(logging.DEBUG):
                 LOGGER.debug('Update process elapsed for {} seconds'.format(time.time() - start))
 
@@ -491,9 +490,6 @@ class Neo4jProxy(BaseProxy):
             raise e
 
         finally:
-
-            tx.close()
-
             if LOGGER.isEnabledFor(logging.DEBUG):
                 LOGGER.debug('Update process elapsed for {} seconds'.format(time.time() - start))
 
@@ -532,14 +528,12 @@ class Neo4jProxy(BaseProxy):
                 raise RuntimeError('Failed to create relation between '
                                    'owner {owner} and table {tbl}'.format(owner=owner,
                                                                           tbl=table_uri))
+            tx.commit()
         except Exception as e:
             if not tx.closed():
                 tx.rollback()
             # propagate the exception back to api
             raise e
-        finally:
-            tx.commit()
-            tx.close()
 
     @timer_with_counter
     def delete_owner(self, *,
@@ -567,7 +561,6 @@ class Neo4jProxy(BaseProxy):
             raise e
         finally:
             tx.commit()
-            tx.close()
 
     @timer_with_counter
     def add_tag(self, *,
@@ -628,9 +621,6 @@ class Neo4jProxy(BaseProxy):
                 tx.rollback()
             # propagate the exception back to api
             raise e
-        finally:
-            if not tx.closed():
-                tx.close()
 
     @timer_with_counter
     def delete_tag(self, *,
@@ -662,14 +652,12 @@ class Neo4jProxy(BaseProxy):
             tx.run(delete_query, {'tag': tag,
                                   'key': id,
                                   'tag_type': tag_type})
+            tx.commit()
         except Exception as e:
             # propagate the exception back to api
             if not tx.closed():
                 tx.rollback()
             raise e
-        finally:
-            tx.commit()
-            tx.close()
 
     @timer_with_counter
     def get_tags(self) -> List:
@@ -1049,8 +1037,6 @@ class Neo4jProxy(BaseProxy):
                 tx.rollback()
             # propagate the exception back to api
             raise e
-        finally:
-            tx.close()
 
     @timer_with_counter
     def delete_resource_relation_by_user(self, *,
@@ -1086,8 +1072,6 @@ class Neo4jProxy(BaseProxy):
             if not tx.closed():
                 tx.rollback()
             raise e
-        finally:
-            tx.close()
 
     @timer_with_counter
     def get_dashboard(self,

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.5.4rc0'
+__version__ = '2.5.4'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 
 from setuptools import setup, find_packages
 
-__version__ = '2.5.3'
+__version__ = '2.5.4rc0'
 
 
 requirements_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')


### PR DESCRIPTION
### Summary of Changes

Recent Neo4j driver [upgrade](https://github.com/lyft/amundsenmetadatalibrary/pull/139) broke many add/delete APIs and this is due to behavior change of Neo4j driver.

- Remove tx.close() due to the behavior change from 1.7.2 that tx.commit() closes the transaction and following tx.close() call throws exception.

`  File \"python3.6/site-packages/neo4j/__init__.py\", line 853, in _assert_open
    raise TransactionError(\"Transaction closed\")
neo4j.TransactionError", "call_site": "site-packages/metadata_service/api/user.py:142", "uri_path": "/user/jinchang@lyft.com/follow/table/hive://gold.*****/********", "revision": "4735a73662", "msg": "UserFollowAPI DELETE Failed"}
`
### Tests

Integration test done on APIs below:

- add description
- add owner
- delete owner
- add tag
- delete tag
- add bookmark
- delete bookmark


### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
