### PR TITLE
feat: Add resource_reports field in Table API  ( Atlas proxy)

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -4,7 +4,7 @@ from random import randint
 from typing import Any, Dict, List, Union, Optional
 
 from amundsen_common.models.popular_table import PopularTable
-from amundsen_common.models.table import Column, Statistics, Table, Tag, User, TableReport
+from amundsen_common.models.table import Column, Statistics, Table, Tag, User, ResourceReport
 from amundsen_common.models.user import User as UserEntity
 from amundsen_common.models.dashboard import DashboardSummary
 from atlasclient.client import Atlas
@@ -363,7 +363,6 @@ class AtlasProxy(BaseProxy):
 
         try:
             attrs = table_details[self.ATTRS_KEY]
-
             table_qn = parse_table_qualified_name(
                 qualified_name=attrs.get(self.QN_KEY)
             )
@@ -387,7 +386,7 @@ class AtlasProxy(BaseProxy):
                     if report_entity.entity[self.ENTITY_STATUS] == self.ENTITY_ACTIVE_STATUS:
                         report_attrs = report_entity.entity[self.ATTRS_KEY]
                         reports.append(
-                            TableReport(
+                            ResourceReport(
                                 name=report_attrs['name'],
                                 url=report_attrs['url']
                             )
@@ -406,7 +405,7 @@ class AtlasProxy(BaseProxy):
                 tags=tags,
                 description=attrs.get('description') or attrs.get('comment'),
                 owners=[User(email=attrs.get('owner'))],
-                table_reports=reports,
+                resource_reports=reports,
                 columns=columns,
                 last_updated_timestamp=self._parse_date(table_details.get('updateTime')))
             return table

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -381,7 +381,6 @@ class AtlasProxy(BaseProxy):
             for report in attrs.get("reports") or list():
                 LOGGER.info("Getting matadata for table Report GUID:{}".format(report.get("guid")))
                 report_entity = self._driver.entity_guid(report.get("guid"))
-
                 try:
                     if report_entity.entity[self.ENTITY_STATUS] == self.ENTITY_ACTIVE_STATUS:
                         report_attrs = report_entity.entity[self.ATTRS_KEY]
@@ -393,7 +392,7 @@ class AtlasProxy(BaseProxy):
                         )
                 except KeyError as ex:
                     LOGGER.exception('Error while accessing table report guid {}. {}'
-                                     .format(report.get("guid"),str(ex)))
+                                     .format(report.get("guid"), str(ex)))
 
             columns = self._serialize_columns(entity=entity)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ typing==3.6.4
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
-amundsen-common>=0.3.1,<1.0
+amundsen-common>=0.3.6,<1.0
 
 flasgger==0.9.3
 Flask-RESTful==0.3.6

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -95,7 +95,8 @@ class Data:
             'owner': 'dummy@email.com',
             'db': db_entity,
             'popularityScore': 100,
-            'partitions': list()
+            'partitions': list(),
+            'reports' : [{'guid' : '23'},{'guid': '121212'}, {'guid':'2344'}]
         },
         'relationshipAttributes': {
             'db': db_entity,
@@ -166,3 +167,27 @@ class Data:
             bookmark_entity2,
         ]
     }
+
+    report_entity_1 = {
+            'typeName': 'Report',
+            'status': 'ACTIVE',
+                      'attributes': {
+        'name': "test_report",
+        'url': "http://test"
+    }}
+    report_entity_2 = {
+            'typeName': 'Report',
+            'status': 'DELETED',
+                      'attributes': {
+        'name': "test_report2",
+        'url': "http://test2"
+    }}
+    report_entity_3 = {
+            'typeName': 'Report',
+            'status': 'ACTIVE',
+                      'attributes': {
+        'name': "test_report3",
+        'url': "http://test3"
+    }}
+
+    report_entities = [report_entity_1,report_entity_2,report_entity_3]


### PR DESCRIPTION
### Summary of Changes

Add resource_reports field in Table API ( atlas proxy)  to support integration with tools generating static HTML reports, such as [popmon](https://github.com/ing-bank/popmon), [pandas-profiling]( https://github.com/pandas-profiling/pandas-profiling) or [great_expectations](https://github.com/great-expectations/great_expectations)..

### Tests

Updated existing unit tests

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`

Resolve lyft/amundsen#525
