### PR TITLE
feat: Add resource_reports field in Table API ( Atlas proxy)

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -61,6 +61,8 @@ class Config:
 
     USER_DETAIL_METHOD = None   # type: Optional[function]
 
+    RESOURCE_REPORT_CLIENT = None   #type: Optional[function]
+
     # On User detail method, these keys will be added into amundsen_common.models.user.User.other_key_values
     USER_OTHER_KEYS = {'mode_user_id'}  # type: Set[str]
 

--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -61,7 +61,7 @@ class Config:
 
     USER_DETAIL_METHOD = None   # type: Optional[function]
 
-    RESOURCE_REPORT_CLIENT = None   #type: Optional[function]
+    RESOURCE_REPORT_CLIENT = None   # type: Optional[function]
 
     # On User detail method, these keys will be added into amundsen_common.models.user.User.other_key_values
     USER_OTHER_KEYS = {'mode_user_id'}  # type: Set[str]

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -349,20 +349,19 @@ class AtlasProxy(BaseProxy):
         reports = []
         if guids:
             report_entities_collection = self._driver.entity_bulk(guid=guids)
-            for report_entities in report_entities_collection:
-                for report_entity in report_entities.entities:
-                    try:
-                        if report_entity.status == self.ENTITY_ACTIVE_STATUS:
-                            report_attrs = report_entity.attributes
-                            reports.append(
-                                ResourceReport(
-                                    name=report_attrs['name'],
-                                    url=report_attrs['url']
-                                )
+            for report_entity in extract_entities(report_entities_collection):
+                try:
+                    if report_entity.status == self.ENTITY_ACTIVE_STATUS:
+                        report_attrs = report_entity.attributes
+                        reports.append(
+                            ResourceReport(
+                                name=report_attrs['name'],
+                                url=report_attrs['url']
                             )
-                    except (KeyError, AttributeError) as ex:
-                        LOGGER.exception('Error while accessing table report: {}. {}'
-                                         .format(str(report_entity), str(ex)))
+                        )
+                except (KeyError, AttributeError) as ex:
+                    LOGGER.exception('Error while accessing table report: {}. {}'
+                                     .format(str(report_entity), str(ex)))
 
         parsed_reports = app.config['RESOURCE_REPORT_CLIENT'](reports) \
             if app.config['RESOURCE_REPORT_CLIENT'] else reports

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -7,7 +7,8 @@ from random import randint
 from typing import Any, Dict, List, Union, Optional
 
 from amundsen_common.models.popular_table import PopularTable
-from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader, ProgrammaticDescription, ResourceReport
+from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader,\
+    ProgrammaticDescription, ResourceReport
 from amundsen_common.models.user import User as UserEntity
 from amundsen_common.models.dashboard import DashboardSummary
 from atlasclient.client import Atlas

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,7 +42,7 @@ typing==3.6.4
 
 # A common package that holds the models deifnition and schemas that are used
 # accross different amundsen repositories.
-amundsen-common>=0.3.1,<1.0
+amundsen-common>=0.3.6,<1.0
 
 flasgger==0.9.3
 Flask-RESTful==0.3.6

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -95,7 +95,8 @@ class Data:
             'owner': 'dummy@email.com',
             'db': db_entity,
             'popularityScore': 100,
-            'partitions': list()
+            'partitions': list(),
+            'reports': [{'guid': '23'}, {'guid': '121212'}, {'guid': '2344'}]
         },
         'relationshipAttributes': {
             'db': db_entity,
@@ -166,3 +167,27 @@ class Data:
             bookmark_entity2,
         ]
     }
+
+    report_entity_1 = {
+        'typeName': 'Report',
+        'status': 'ACTIVE',
+        'attributes': {
+            'name': "test_report",
+            'url': "http://test"
+        }}
+    report_entity_2 = {
+        'typeName': 'Report',
+        'status': 'DELETED',
+        'attributes': {
+            'name': "test_report2",
+            'url': "http://test2"
+        }}
+    report_entity_3 = {
+        'typeName': 'Report',
+        'status': 'ACTIVE',
+        'attributes': {
+            'name': "test_report3",
+            'url': "http://test3"
+        }}
+
+    report_entities = [report_entity_1, report_entity_2, report_entity_3]

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -88,17 +88,16 @@ class TestAtlasProxy(unittest.TestCase, Data):
 
         self.assertEqual(ent.__repr__(), unique_attr_response.__repr__())
 
-    def _create_mocked_report_entity(self, entity):
-        mocked_report_entity = MagicMock()
-        mocked_report_entity.status = entity["status"]
-        mocked_report_entity.attributes = entity["attributes"]
-        return mocked_report_entity
-
-    def _create_mockerd_report_entities_collection(self):
+    def _create_mocked_report_entities_collection(self) -> None:
         mocked_report_entities_collection = MagicMock()
-        mocked_report_entities_collection.entities = [self._create_mocked_report_entity(report_entity)
-                                                      for report_entity in self.report_entities]
-        return [mocked_report_entities_collection]
+        mocked_report_entities_collection.entities = []
+        for entity in self.report_entities:
+            mocked_report_entity = MagicMock()
+            mocked_report_entity.status = entity['status']
+            mocked_report_entity.attributes = entity['attributes']
+            mocked_report_entities_collection.entities.append(mocked_report_entity)
+
+        self.report_entity_collection = [mocked_report_entities_collection]
 
     def _get_table(self, custom_stats_format: bool = False) -> None:
         if custom_stats_format:
@@ -107,8 +106,8 @@ class TestAtlasProxy(unittest.TestCase, Data):
             test_exp_col = self.test_exp_col_stats_raw
 
         self._mock_get_table_entity()
-        report_entity_collection = self._create_mockerd_report_entities_collection()
-        self.proxy._driver.entity_bulk = MagicMock(return_value=report_entity_collection)
+        self._create_mocked_report_entities_collection()
+        self.proxy._driver.entity_bulk = MagicMock(return_value=self.report_entity_collection)
         response = self.proxy.get_table(table_uri=self.table_uri)
 
         classif_name = self.classification_entity['classifications'][0]['typeName']

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -6,7 +6,8 @@ import unittest
 from typing import Any, Dict, Optional, cast, List
 
 from amundsen_common.models.popular_table import PopularTable
-from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader, ProgrammaticDescription, ResourceReport
+from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader,\
+    ProgrammaticDescription, ResourceReport
 from atlasclient.exceptions import BadRequest
 from mock import MagicMock, patch
 from tests.unit.proxy.fixtures.atlas_test_data import Data, DottedDict


### PR DESCRIPTION
### Summary of Changes

Add resource_reports field in Table API ( atlas proxy)  to support integration with tools generating static HTML reports, such as [popmon](https://github.com/ing-bank/popmon), [pandas-profiling]( https://github.com/pandas-profiling/pandas-profiling) or [great_expectations](https://github.com/great-expectations/great_expectations)..

### Tests

Updated existing unit tests

### Documentation

N/A

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`

Resolve lyft/amundsen#525