### PR TITLE
feat: Add programmatic descriptions parser for [AtlasProxy]

### DIFF
--- a/metadata_service/config.py
+++ b/metadata_service/config.py
@@ -67,6 +67,9 @@ class Config:
     # Number of minimum reader count to qualify for popular table
     POPULAR_TABLE_MINIMUM_READER_COUNT = 10  # type: int
 
+    # List of regexes which will exclude certain parameters from appearing as Programmatic Descriptions
+    PROGRAMMATIC_DESCRIPTIONS_EXCLUDE_FILTERS = []  # type: list
+
 
 class LocalConfig(Config):
     DEBUG = True

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -4,7 +4,7 @@ from random import randint
 from typing import Any, Dict, List, Union, Optional
 
 from amundsen_common.models.popular_table import PopularTable
-from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader
+from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader, ProgrammaticDescription
 from amundsen_common.models.user import User as UserEntity
 from amundsen_common.models.dashboard import DashboardSummary
 from atlasclient.client import Atlas
@@ -363,6 +363,8 @@ class AtlasProxy(BaseProxy):
         try:
             attrs = table_details[self.ATTRS_KEY]
 
+            programmatic_descriptions = self._get_programmatic_descriptions(attrs.get('parameters'))
+
             table_qn = parse_table_qualified_name(
                 qualified_name=attrs.get(self.QN_KEY)
             )
@@ -389,7 +391,8 @@ class AtlasProxy(BaseProxy):
                 owners=[User(email=attrs.get('owner'))],
                 columns=columns,
                 table_readers=self._get_readers(attrs.get(self.QN_KEY)),
-                last_updated_timestamp=self._parse_date(table_details.get('updateTime')))
+                last_updated_timestamp=self._parse_date(table_details.get('updateTime')),
+                programmatic_descriptions=programmatic_descriptions)
 
             return table
         except KeyError as ex:
@@ -735,6 +738,27 @@ class AtlasProxy(BaseProxy):
                 results.append(reader)
 
         return results
+
+    def _get_programmatic_descriptions(self, parameters: dict) -> List[ProgrammaticDescription]:
+        programmatic_descriptions: List[ProgrammaticDescription] = {}
+
+        for source, text in parameters.items():
+            use_parameter = True
+
+            for regex_filter in app.config['PROGRAMMATIC_DESCRIPTIONS_EXCLUDE_FILTERS']:
+                pattern = re.compile(regex_filter)
+
+                if pattern.match(source):
+                    use_parameter = False
+                    break
+
+            if use_parameter:
+                source = re.sub("([a-z])([A-Z])", "\g<1> \g<2>", source).lower()
+                programmatic_descriptions[source] = ProgrammaticDescription(source=source, text=text)
+
+        programmatic_descriptions = dict(sorted(programmatic_descriptions.items()))
+
+        return list(programmatic_descriptions.values())
 
     def get_dashboard(self,
                       dashboard_uri: str,

--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -740,7 +740,7 @@ class AtlasProxy(BaseProxy):
         return results
 
     def _get_programmatic_descriptions(self, parameters: dict) -> List[ProgrammaticDescription]:
-        programmatic_descriptions: List[ProgrammaticDescription] = {}
+        programmatic_descriptions: Dict[str, ProgrammaticDescription] = {}
 
         for source, text in parameters.items():
             use_parameter = True
@@ -756,9 +756,9 @@ class AtlasProxy(BaseProxy):
                 source = re.sub("([a-z])([A-Z])", "\g<1> \g<2>", source).lower()
                 programmatic_descriptions[source] = ProgrammaticDescription(source=source, text=text)
 
-        programmatic_descriptions = dict(sorted(programmatic_descriptions.items()))
+        result = dict(sorted(programmatic_descriptions.items()))
 
-        return list(programmatic_descriptions.values())
+        return list(result.values())
 
     def get_dashboard(self,
                       dashboard_uri: str,

--- a/tests/unit/proxy/fixtures/atlas_test_data.py
+++ b/tests/unit/proxy/fixtures/atlas_test_data.py
@@ -102,7 +102,12 @@ class Data:
             'owner': 'dummy@email.com',
             'db': db_entity,
             'popularityScore': 100,
-            'partitions': list()
+            'partitions': list(),
+            'parameters': {
+                'testParameterKeyB': 'testParameterValueB',
+                'testParameterKeyA': 'testParameterValueA',
+                'spark.sql.param': 1
+            }
         },
         'relationshipAttributes': {
             'db': db_entity,

--- a/tests/unit/proxy/test_atlas_proxy.py
+++ b/tests/unit/proxy/test_atlas_proxy.py
@@ -3,7 +3,7 @@ import unittest
 from typing import Any, Dict, Optional, cast, List
 
 from amundsen_common.models.popular_table import PopularTable
-from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader
+from amundsen_common.models.table import Column, Statistics, Table, Tag, User, Reader, ProgrammaticDescription
 from atlasclient.exceptions import BadRequest
 from mock import MagicMock, patch
 from tests.unit.proxy.fixtures.atlas_test_data import Data, DottedDict
@@ -18,6 +18,7 @@ from metadata_service.entity.resource_type import ResourceType
 class TestAtlasProxy(unittest.TestCase, Data):
     def setUp(self) -> None:
         self.app = create_app(config_module_class='metadata_service.config.LocalConfig')
+        self.app.config['PROGRAMMATIC_DESCRIPTIONS_EXCLUDE_FILTERS'] = ['spark.*']
         self.app_context = self.app.app_context()
         self.app_context.push()
 
@@ -126,7 +127,12 @@ class TestAtlasProxy(unittest.TestCase, Data):
                          description=ent_attrs['description'],
                          owners=[User(email=ent_attrs['owner'])],
                          last_updated_timestamp=int(str(self.entity1['updateTime'])[:10]),
-                         columns=[exp_col] * self.active_columns)
+                         columns=[exp_col] * self.active_columns,
+                         programmatic_descriptions=[ProgrammaticDescription(source='test parameter key a',
+                                                                            text='testParameterValueA'),
+                                                    ProgrammaticDescription(source='test parameter key b',
+                                                                            text='testParameterValueB')
+                                                    ])
 
         self.assertEqual(str(expected), str(response))
 


### PR DESCRIPTION
### Summary of Changes

This MR introduces parsing of programmatic descriptions using **parameters** field of Table entity in Atlas Proxy. The parameters field is a map of String -> Any and seems like a perfect fit for this usecase.

Moreover, this property can be set for example on hive_table entity programatically with spark sql:

`ALTER [TABLE|VIEW] table_name SET TBLPROPERTIES (key1=val1, key2=val2, ...)` - Atlas hive-hook will propagate such action in Hive Metastore to Atlas metadata

All of those key1, key2 etc then become programmatic description entries.

The idea is also to have a filter to remove unwanted properties (like spark technical ones that appear in parameters after creating table with spark). This could also be of use for other proxies.

### Tests

Tested for presence and filtering of programmatic desriptions.

### Documentation

_What documentation did you add or modify and why? Add any relevant links then remove this line_

### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
