### PR TITLE
fix: Overlapping table name issue in Readers [AtlasProxy]

### DIFF
--- a/metadata_service/proxy/atlas_proxy.py
+++ b/metadata_service/proxy/atlas_proxy.py
@@ -707,7 +707,7 @@ class AtlasProxy(BaseProxy):
                     {
                         'attributeName': self.QN_KEY,
                         'operator': 'STARTSWITH',
-                        'attributeValue': qualified_name.split('@')[0]
+                        'attributeValue': qualified_name.split('@')[0] + '.'
                     },
                     {
                         'attributeName': 'count',


### PR DESCRIPTION
### Summary of Changes

Add a period to distincly separate table name end. Otherwise, table which names overlaps with beginning of another tables name (like table_name and table_name_test) will present also readers for table_name_test.

### Tests


### Documentation


### CheckList
Make sure you have checked **all** steps below to ensure a timely review.
- [x] PR title addresses the issue accurately and concisely. Example: "Updates the version of Flask to v1.0.2"
    - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
- [x] PR includes a summary of changes. 
- [x] PR adds unit tests, updates existing unit tests, __OR__ documents why no test additions or modifications are needed.
- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain docstrings that explain what it does
- [x] PR passes `make test`
